### PR TITLE
Experimental: autohide AppBar, .NET 8, WinAppSDK 1.8, CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,18 +75,24 @@ jobs:
       # -----------------------------------------------------------------------
       # Option B — Unpackaged, runtime-dependent. Target machine needs the
       # Windows App Runtime 1.5 installer (https://aka.ms/windowsappsdk).
+      #
+      # Uses msbuild.exe (from VS) rather than `dotnet publish` because the
+      # Windows App SDK 1.5 targets reference Microsoft.Build.Packaging.Pri.Tasks.dll,
+      # which ships with Visual Studio — not with the standalone dotnet SDK
+      # (MSB4062 otherwise).
       # -----------------------------------------------------------------------
       - name: Build unpackaged runtime-dependent (Option B)
         shell: pwsh
         run: |
-          dotnet publish $env:Solution `
-            -c $env:Configuration `
-            -r win-x64 `
-            --self-contained false `
-            -p:WindowsPackageType=None `
-            -p:Platform=$env:Platform `
-            -p:PublishReadyToRun=false `
-            -o publish\unpackaged-runtime-dep
+          msbuild $env:Solution `
+            /restore `
+            /t:Publish `
+            /p:Configuration=$env:Configuration `
+            /p:Platform=$env:Platform `
+            /p:RuntimeIdentifier=win-x64 `
+            /p:SelfContained=false `
+            /p:WindowsPackageType=None `
+            /p:PublishDir="$env:GITHUB_WORKSPACE\publish\unpackaged-runtime-dep\\"
 
       # -----------------------------------------------------------------------
       # Option C — Unpackaged, fully self-contained. ~100 MB, portable, no prereqs.
@@ -94,15 +100,16 @@ jobs:
       - name: Build unpackaged self-contained (Option C)
         shell: pwsh
         run: |
-          dotnet publish $env:Solution `
-            -c $env:Configuration `
-            -r win-x64 `
-            --self-contained true `
-            -p:WindowsPackageType=None `
-            -p:WindowsAppSDKSelfContained=true `
-            -p:Platform=$env:Platform `
-            -p:PublishReadyToRun=false `
-            -o publish\unpackaged-self-contained
+          msbuild $env:Solution `
+            /restore `
+            /t:Publish `
+            /p:Configuration=$env:Configuration `
+            /p:Platform=$env:Platform `
+            /p:RuntimeIdentifier=win-x64 `
+            /p:SelfContained=true `
+            /p:WindowsAppSDKSelfContained=true `
+            /p:WindowsPackageType=None `
+            /p:PublishDir="$env:GITHUB_WORKSPACE\publish\unpackaged-self-contained\\"
 
       - name: Upload MSIX artifact
         if: steps.msix.outcome == 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
           # symbols), and the raw .cer from the MSIX build (we use our own ci-cert).
           path: |
             publish/msix/*_Test/**/*.msix
+            publish/msix/*_Test/*.cer
             publish/msix/*_Test/Install.ps1
             publish/msix/*_Test/Add-AppDevPackage.ps1
             publish/msix/*_Test/Add-AppDevPackage.resources/en-US/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,142 @@
+name: Build
+
+on:
+  push:
+    branches: [Experimental, master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      Configuration: Release
+      Platform: x64
+      Solution: AppAppBar3/AppAppBar3.csproj
+      # Publisher must match the one in Package.appxmanifest exactly for MSIX signing.
+      CertSubject: CN=tomho
+      PfxPassword: appbar-ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Generate self-signed code-signing cert
+        id: cert
+        shell: pwsh
+        run: |
+          $cert = New-SelfSignedCertificate `
+            -Type CodeSigningCert `
+            -Subject "$env:CertSubject" `
+            -KeyUsage DigitalSignature `
+            -CertStoreLocation "Cert:\CurrentUser\My" `
+            -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+          $pwd = ConvertTo-SecureString -String "$env:PfxPassword" -Force -AsPlainText
+          $pfxPath = "$env:GITHUB_WORKSPACE\AppAppBar3\ci-cert.pfx"
+          $cerPath = "$env:GITHUB_WORKSPACE\AppAppBar3\ci-cert.cer"
+          Export-PfxCertificate  -Cert $cert -FilePath $pfxPath -Password $pwd | Out-Null
+          Export-Certificate     -Cert $cert -FilePath $cerPath                 | Out-Null
+          "thumbprint=$($cert.Thumbprint)"       | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "pfx=AppAppBar3\ci-cert.pfx"           | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "cer=$cerPath"                         | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # -----------------------------------------------------------------------
+      # Option A — MSIX package (signed with the CI-generated self-signed cert).
+      # MSIX subscribers must import ci-cert.cer into "Trusted People" on their
+      # machine before installing the .msix, since the cert isn't a public CA.
+      # -----------------------------------------------------------------------
+      - name: Build MSIX (Option A)
+        id: msix
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          msbuild $env:Solution `
+            /restore `
+            /p:Configuration=$env:Configuration `
+            /p:Platform=$env:Platform `
+            /p:AppxPackageSigningEnabled=true `
+            /p:PackageCertificateKeyFile="${{ steps.cert.outputs.pfx }}" `
+            /p:PackageCertificateThumbprint="${{ steps.cert.outputs.thumbprint }}" `
+            /p:PackageCertificatePassword="$env:PfxPassword" `
+            /p:GenerateAppxPackageOnBuild=true `
+            /p:AppxBundle=Never `
+            /p:UapAppxPackageBuildMode=SideloadOnly `
+            /p:AppxPackageDir="$env:GITHUB_WORKSPACE\publish\msix\\"
+
+      # -----------------------------------------------------------------------
+      # Option B — Unpackaged, runtime-dependent. Target machine needs the
+      # Windows App Runtime 1.5 installer (https://aka.ms/windowsappsdk).
+      # -----------------------------------------------------------------------
+      - name: Build unpackaged runtime-dependent (Option B)
+        shell: pwsh
+        run: |
+          dotnet publish $env:Solution `
+            -c $env:Configuration `
+            -r win-x64 `
+            --self-contained false `
+            -p:WindowsPackageType=None `
+            -p:Platform=$env:Platform `
+            -p:PublishReadyToRun=false `
+            -o publish\unpackaged-runtime-dep
+
+      # -----------------------------------------------------------------------
+      # Option C — Unpackaged, fully self-contained. ~100 MB, portable, no prereqs.
+      # -----------------------------------------------------------------------
+      - name: Build unpackaged self-contained (Option C)
+        shell: pwsh
+        run: |
+          dotnet publish $env:Solution `
+            -c $env:Configuration `
+            -r win-x64 `
+            --self-contained true `
+            -p:WindowsPackageType=None `
+            -p:WindowsAppSDKSelfContained=true `
+            -p:Platform=$env:Platform `
+            -p:PublishReadyToRun=false `
+            -o publish\unpackaged-self-contained
+
+      - name: Upload MSIX artifact
+        if: steps.msix.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: AppAppBar3-MSIX-x64
+          path: |
+            publish/msix/**
+            AppAppBar3/ci-cert.cer
+          if-no-files-found: warn
+
+      - name: Upload unpackaged runtime-dependent artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AppAppBar3-Unpackaged-RuntimeDep-x64
+          path: publish/unpackaged-runtime-dep/
+          if-no-files-found: error
+
+      - name: Upload unpackaged self-contained artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AppAppBar3-Unpackaged-SelfContained-x64
+          path: publish/unpackaged-self-contained/
+          if-no-files-found: error
+
+      - name: Summary
+        if: always()
+        shell: pwsh
+        run: |
+          $msixState = "${{ steps.msix.outcome }}"
+          Add-Content $env:GITHUB_STEP_SUMMARY "## Build artifacts`n"
+          Add-Content $env:GITHUB_STEP_SUMMARY "| Variant | Status |"
+          Add-Content $env:GITHUB_STEP_SUMMARY "|---|---|"
+          Add-Content $env:GITHUB_STEP_SUMMARY "| A — MSIX (signed, sideload) | $msixState |"
+          Add-Content $env:GITHUB_STEP_SUMMARY "| B — Unpackaged, runtime-dep | success |"
+          Add-Content $env:GITHUB_STEP_SUMMARY "| C — Unpackaged, self-contained | success |"
+          Add-Content $env:GITHUB_STEP_SUMMARY "`nMSIX install: import **ci-cert.cer** into *Local Machine > Trusted People* first, then double-click the .msix."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET 6
+      - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
             /p:PackageCertificateThumbprint="${{ steps.cert.outputs.thumbprint }}" `
             /p:PackageCertificatePassword="$env:PfxPassword" `
             /p:GenerateAppxPackageOnBuild=true `
+            /p:GenerateAppInstallerFile=false `
             /p:AppxBundle=Never `
             /p:UapAppxPackageBuildMode=SideloadOnly `
             /p:AppxPackageDir="$env:GITHUB_WORKSPACE\publish\msix\\"
@@ -116,8 +117,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: AppAppBar3-MSIX-x64
+          # Sideload-ready contents only — excludes .appinstaller (invalid auto-update
+          # manifest from the stale AppInstallerUri in the csproj), .appxsym (debug
+          # symbols), and the raw .cer from the MSIX build (we use our own ci-cert).
           path: |
-            publish/msix/**
+            publish/msix/*_Test/**/*.msix
+            publish/msix/*_Test/Install.ps1
+            publish/msix/*_Test/Add-AppDevPackage.ps1
+            publish/msix/*_Test/Add-AppDevPackage.resources/en-US/**
             AppAppBar3/ci-cert.cer
           if-no-files-found: warn
 

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# CI-generated self-signed cert (build.yml)
+ci-cert.pfx
+ci-cert.cer

--- a/AppAppBar3.sln
+++ b/AppAppBar3.sln
@@ -13,6 +13,9 @@ Global
 		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		x64test|ARM64 = x64test|ARM64
+		x64test|x64 = x64test|x64
+		x64test|x86 = x64test|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EABBC16C-D079-4DC8-A479-07FB13A49602}.Debug|ARM64.ActiveCfg = Debug|ARM64
@@ -33,6 +36,15 @@ Global
 		{EABBC16C-D079-4DC8-A479-07FB13A49602}.Release|x86.ActiveCfg = Release|x86
 		{EABBC16C-D079-4DC8-A479-07FB13A49602}.Release|x86.Build.0 = Release|x86
 		{EABBC16C-D079-4DC8-A479-07FB13A49602}.Release|x86.Deploy.0 = Release|x86
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|ARM64.ActiveCfg = x64test|ARM64
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|ARM64.Build.0 = x64test|ARM64
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|ARM64.Deploy.0 = x64test|ARM64
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|x64.ActiveCfg = x64test|x64
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|x64.Build.0 = x64test|x64
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|x64.Deploy.0 = x64test|x64
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|x86.ActiveCfg = x64test|x86
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|x86.Build.0 = x64test|x86
+		{EABBC16C-D079-4DC8-A479-07FB13A49602}.x64test|x86.Deploy.0 = x64test|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AppAppBar3/App.xaml.cs
+++ b/AppAppBar3/App.xaml.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;

--- a/AppAppBar3/App.xaml.cs
+++ b/AppAppBar3/App.xaml.cs
@@ -33,6 +33,23 @@ namespace AppAppBar3
         public App()
         {
             this.InitializeComponent();
+
+            // Catch-all for otherwise-fatal exceptions on the UI thread.
+            this.UnhandledException += OnUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+                System.Diagnostics.Debug.WriteLine("[AppDomain] Unhandled: " + e.ExceptionObject);
+            System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (s, e) =>
+            {
+                System.Diagnostics.Debug.WriteLine("[Task] Unobserved: " + e.Exception);
+                e.SetObserved();
+            };
+        }
+
+        private void OnUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine($"[XAML] Unhandled: {e.Message}{Environment.NewLine}{e.Exception}");
+            // Keep the app alive after reporting — a stray handler exception shouldn't kill the appbar.
+            e.Handled = true;
         }
 
         /// <summary>

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -22,6 +22,7 @@
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AssemblyName>AppAppBar3</AssemblyName>
     <PackageCertificateThumbprint>2C316BF94DE42C49EEE29DF14679C9ACEA1FB94D</PackageCertificateThumbprint>
+    <Configurations>Debug;Release;x64test</Configurations>
   </PropertyGroup>
 
   <!--

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>AppAppBar3</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -52,8 +52,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.6" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
     <PackageReference Include="WinUIEx" Version="2.4.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -52,10 +52,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="WinUIEx" Version="2.4.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.6" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
-    <PackageReference Include="WinUIEx" Version="2.4.0" />
+    <PackageReference Include="WinUIEx" Version="2.9.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -42,18 +42,6 @@
     <None Remove="WindowDetect.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="IWshRuntimeLibrary">
-      <WrapperTool>tlbimp</WrapperTool>
-      <VersionMinor>0</VersionMinor>
-      <VersionMajor>1</VersionMajor>
-      <Guid>f935dc20-1cf0-11d0-adb9-00c04fd58a0b</Guid>
-      <Lcid>0</Lcid>
-      <Isolated>false</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />
     <Content Include="Assets\Square150x150Logo.scale-200.png" />

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>AppAppBar3</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <StartupObject></StartupObject>

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -23,6 +23,19 @@
     <AssemblyName>AppAppBar3</AssemblyName>
     <PackageCertificateThumbprint>2C316BF94DE42C49EEE29DF14679C9ACEA1FB94D</PackageCertificateThumbprint>
   </PropertyGroup>
+
+  <!--
+    Unpackaged build opts. Enable by passing  -p:WindowsPackageType=None  on the
+    publish command line (see the README-style block in the commit message).
+    For a fully portable build add      -p:WindowsAppSDKSelfContained=true
+                                        -p:SelfContained=true
+                                        -p:PublishSingleFile=false
+  -->
+  <PropertyGroup Condition="'$(WindowsPackageType)' == 'None'">
+    <EnableMsixTooling>false</EnableMsixTooling>
+    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <GenerateAppInstallerFile>false</GenerateAppInstallerFile>
+  </PropertyGroup>
   <ItemGroup>
     <None Remove="Settings.xaml" />
     <None Remove="WebWindow.xaml" />

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -53,7 +53,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.6" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
     <PackageReference Include="WinUIEx" Version="2.4.0" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/AppAppBar3/AppAppBar3.csproj
+++ b/AppAppBar3/AppAppBar3.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
     <PackageReference Include="WinUIEx" Version="2.4.0" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -270,6 +270,12 @@ namespace AppAppBar3
         {
             StopAutohideTimer();
 
+            Debug.WriteLine($"[ApplyDocked] edge={edge} barSizeScaled={barSizeScaled} " +
+                $"monitorScale={targetMonitor.scale} MonitorRect=({targetMonitor.MonitorRect.left},{targetMonitor.MonitorRect.top})-" +
+                $"({targetMonitor.MonitorRect.right},{targetMonitor.MonitorRect.bottom}) " +
+                $"WorkRect=({targetMonitor.WorkRect.left},{targetMonitor.WorkRect.top})-" +
+                $"({targetMonitor.WorkRect.right},{targetMonitor.WorkRect.bottom})");
+
             var abd = new APPBARDATA();
             abd.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
             abd.hWnd = hWnd;
@@ -281,22 +287,35 @@ namespace AppAppBar3
             // proposal, and it does so asymmetrically for Left vs Right.
             abd.rc = targetMonitor.MonitorRect;
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
+            Debug.WriteLine($"[ApplyDocked] pre-QUERYPOS rc=({abd.rc.left},{abd.rc.top})-({abd.rc.right},{abd.rc.bottom}) w={abd.rc.right - abd.rc.left}");
 
             SHAppBarMessage((int)AppBarMessages.ABM_QUERYPOS, ref abd);
+            Debug.WriteLine($"[ApplyDocked] post-QUERYPOS rc=({abd.rc.left},{abd.rc.top})-({abd.rc.right},{abd.rc.bottom}) w={abd.rc.right - abd.rc.left}");
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             SHAppBarMessage((int)AppBarMessages.ABM_SETPOS, ref abd);
+            Debug.WriteLine($"[ApplyDocked] post-SETPOS rc=({abd.rc.left},{abd.rc.top})-({abd.rc.right},{abd.rc.bottom}) w={abd.rc.right - abd.rc.left}");
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
             style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
             SetWindowLong(hWnd, GWL_STYLE, style);
+            // SWP_FRAMECHANGED commits the style change and forces WM_NCCALCSIZE before the
+            // move — without this, the window can retain non-client metrics from the old
+            // (captioned/thick-framed) style and the final MoveWindow sizes the wrong frame.
+            SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0,
+                SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 
-            if (!MoveWindow(hWnd, abd.rc.left, abd.rc.top,
-                abd.rc.right - abd.rc.left, abd.rc.bottom - abd.rc.top, true))
+            int moveW = abd.rc.right - abd.rc.left;
+            int moveH = abd.rc.bottom - abd.rc.top;
+            Debug.WriteLine($"[ApplyDocked] MoveWindow({abd.rc.left},{abd.rc.top},{moveW},{moveH})");
+            if (!MoveWindow(hWnd, abd.rc.left, abd.rc.top, moveW, moveH, true))
             {
                 LogWin32Error("MoveWindow (docked)");
             }
+
+            if (GetWindowRect(hWnd, out RECT actual))
+                Debug.WriteLine($"[ApplyDocked] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left} h={actual.bottom - actual.top}");
 
             SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
         }
@@ -387,12 +406,21 @@ namespace AppAppBar3
             IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
             style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
             SetWindowLong(hWnd, GWL_STYLE, style);
+            SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0,
+                SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+
+            Debug.WriteLine($"[ApplyAutohide] edge={edge} barSizeScaled={barSizeScaled} scale={scale} triggerPx={triggerPx} " +
+                $"shown=({shownRect.left},{shownRect.top})-({shownRect.right},{shownRect.bottom}) w={shownRect.right - shownRect.left} " +
+                $"hidden=({hiddenRect.left},{hiddenRect.top})-({hiddenRect.right},{hiddenRect.bottom}) w={hiddenRect.right - hiddenRect.left}");
 
             SetWindowPos(hWnd, HWND_TOPMOST,
                 hiddenRect.left, hiddenRect.top,
                 hiddenRect.right - hiddenRect.left,
                 hiddenRect.bottom - hiddenRect.top,
                 SWP_NOACTIVATE);
+
+            if (GetWindowRect(hWnd, out RECT actual))
+                Debug.WriteLine($"[ApplyAutohide] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left}");
             autohideState = AutohideState.Hidden;
             cursorLeftShownAt = DateTime.MaxValue;
 

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -117,8 +117,14 @@ namespace AppAppBar3
         private const int AutohideTriggerPxUnscaled = 2;
         public MainWindow()
         {
-         
+
             this.InitializeComponent();
+            // Override the XAML MinWidth/MinHeight floor — WinUIEx.WindowEx's
+            // WM_WINDOWPOSCHANGING interceptor was clamping our Left/Right bar up to
+            // ~132 DIPs even when we asked for 50, because MinWidth=25 in XAML wasn't
+            // the actual floor in practice.
+            this.MinWidth = 1;
+            this.MinHeight = 1;
             this.Activated += OnActivated;
             this.AppWindow.IsShownInSwitchers = false;
             monitorInfo = GetMonitorsInfo();
@@ -312,12 +318,15 @@ namespace AppAppBar3
 
             int moveW = abd.rc.right - abd.rc.left;
             int moveH = abd.rc.bottom - abd.rc.top;
-            string moveLine = $"[ApplyDocked] MoveWindow({abd.rc.left},{abd.rc.top},{moveW},{moveH})";
+            string moveLine = $"[ApplyDocked] SetWindowPos({abd.rc.left},{abd.rc.top},{moveW},{moveH})";
             Debug.WriteLine(moveLine);
             SettingMethods.FileLog(moveLine);
-            if (!MoveWindow(hWnd, abd.rc.left, abd.rc.top, moveW, moveH, true))
+            // SWP_NOSENDCHANGING skips WM_WINDOWPOSCHANGING, which WinUIEx.WindowEx was
+            // intercepting to clamp our width up to ~132 DIPs (its content/MinWidth floor).
+            if (!SetWindowPos(hWnd, IntPtr.Zero, abd.rc.left, abd.rc.top, moveW, moveH,
+                SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOSENDCHANGING))
             {
-                LogWin32Error("MoveWindow (docked)");
+                LogWin32Error("SetWindowPos (docked)");
             }
 
             if (GetWindowRect(hWnd, out RECT actual))

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -270,11 +270,15 @@ namespace AppAppBar3
         {
             StopAutohideTimer();
 
-            Debug.WriteLine($"[ApplyDocked] edge={edge} barSizeScaled={barSizeScaled} " +
-                $"monitorScale={targetMonitor.scale} MonitorRect=({targetMonitor.MonitorRect.left},{targetMonitor.MonitorRect.top})-" +
+            int winDpi = GetDpiForWindow(hWnd);
+            string hdr = $"[ApplyDocked] edge={edge} barSizeScaled={barSizeScaled} " +
+                $"monitorScale={targetMonitor.scale} windowDpi={winDpi} " +
+                $"MonitorRect=({targetMonitor.MonitorRect.left},{targetMonitor.MonitorRect.top})-" +
                 $"({targetMonitor.MonitorRect.right},{targetMonitor.MonitorRect.bottom}) " +
                 $"WorkRect=({targetMonitor.WorkRect.left},{targetMonitor.WorkRect.top})-" +
-                $"({targetMonitor.WorkRect.right},{targetMonitor.WorkRect.bottom})");
+                $"({targetMonitor.WorkRect.right},{targetMonitor.WorkRect.bottom})";
+            Debug.WriteLine(hdr);
+            SettingMethods.FileLog(hdr);
 
             var abd = new APPBARDATA();
             abd.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
@@ -287,14 +291,14 @@ namespace AppAppBar3
             // proposal, and it does so asymmetrically for Left vs Right.
             abd.rc = targetMonitor.MonitorRect;
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
-            Debug.WriteLine($"[ApplyDocked] pre-QUERYPOS rc=({abd.rc.left},{abd.rc.top})-({abd.rc.right},{abd.rc.bottom}) w={abd.rc.right - abd.rc.left}");
+            LogRect("pre-QUERYPOS", abd.rc);
 
             SHAppBarMessage((int)AppBarMessages.ABM_QUERYPOS, ref abd);
-            Debug.WriteLine($"[ApplyDocked] post-QUERYPOS rc=({abd.rc.left},{abd.rc.top})-({abd.rc.right},{abd.rc.bottom}) w={abd.rc.right - abd.rc.left}");
+            LogRect("post-QUERYPOS", abd.rc);
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             SHAppBarMessage((int)AppBarMessages.ABM_SETPOS, ref abd);
-            Debug.WriteLine($"[ApplyDocked] post-SETPOS rc=({abd.rc.left},{abd.rc.top})-({abd.rc.right},{abd.rc.bottom}) w={abd.rc.right - abd.rc.left}");
+            LogRect("post-SETPOS", abd.rc);
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
@@ -308,14 +312,20 @@ namespace AppAppBar3
 
             int moveW = abd.rc.right - abd.rc.left;
             int moveH = abd.rc.bottom - abd.rc.top;
-            Debug.WriteLine($"[ApplyDocked] MoveWindow({abd.rc.left},{abd.rc.top},{moveW},{moveH})");
+            string moveLine = $"[ApplyDocked] MoveWindow({abd.rc.left},{abd.rc.top},{moveW},{moveH})";
+            Debug.WriteLine(moveLine);
+            SettingMethods.FileLog(moveLine);
             if (!MoveWindow(hWnd, abd.rc.left, abd.rc.top, moveW, moveH, true))
             {
                 LogWin32Error("MoveWindow (docked)");
             }
 
             if (GetWindowRect(hWnd, out RECT actual))
-                Debug.WriteLine($"[ApplyDocked] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left} h={actual.bottom - actual.top}");
+            {
+                string actualLine = $"[ApplyDocked] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left} h={actual.bottom - actual.top}";
+                Debug.WriteLine(actualLine);
+                SettingMethods.FileLog(actualLine);
+            }
 
             SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
         }
@@ -329,6 +339,13 @@ namespace AppAppBar3
                 case ABEdge.Top:    rc.bottom = rc.top + thickness; break;
                 case ABEdge.Bottom: rc.top    = rc.bottom - thickness; break;
             }
+        }
+
+        private static void LogRect(string label, RECT r)
+        {
+            string line = $"[ApplyDocked] {label} rc=({r.left},{r.top})-({r.right},{r.bottom}) w={r.right - r.left} h={r.bottom - r.top}";
+            Debug.WriteLine(line);
+            SettingMethods.FileLog(line);
         }
 
         private void ApplyAutohide(IntPtr hWnd, ABEdge edge, Monitor targetMonitor, int barSizeScaled)
@@ -409,9 +426,12 @@ namespace AppAppBar3
             SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 
-            Debug.WriteLine($"[ApplyAutohide] edge={edge} barSizeScaled={barSizeScaled} scale={scale} triggerPx={triggerPx} " +
+            int winDpiAh = GetDpiForWindow(hWnd);
+            string ahLine = $"[ApplyAutohide] edge={edge} barSizeScaled={barSizeScaled} scale={scale} windowDpi={winDpiAh} triggerPx={triggerPx} " +
                 $"shown=({shownRect.left},{shownRect.top})-({shownRect.right},{shownRect.bottom}) w={shownRect.right - shownRect.left} " +
-                $"hidden=({hiddenRect.left},{hiddenRect.top})-({hiddenRect.right},{hiddenRect.bottom}) w={hiddenRect.right - hiddenRect.left}");
+                $"hidden=({hiddenRect.left},{hiddenRect.top})-({hiddenRect.right},{hiddenRect.bottom}) w={hiddenRect.right - hiddenRect.left}";
+            Debug.WriteLine(ahLine);
+            SettingMethods.FileLog(ahLine);
 
             SetWindowPos(hWnd, HWND_TOPMOST,
                 hiddenRect.left, hiddenRect.top,
@@ -420,7 +440,11 @@ namespace AppAppBar3
                 SWP_NOACTIVATE);
 
             if (GetWindowRect(hWnd, out RECT actual))
-                Debug.WriteLine($"[ApplyAutohide] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left}");
+            {
+                string actualAh = $"[ApplyAutohide] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left}";
+                Debug.WriteLine(actualAh);
+                SettingMethods.FileLog(actualAh);
+            }
             autohideState = AutohideState.Hidden;
             cursorLeftShownAt = DateTime.MaxValue;
 

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -276,16 +276,6 @@ namespace AppAppBar3
         {
             StopAutohideTimer();
 
-            int winDpi = GetDpiForWindow(hWnd);
-            string hdr = $"[ApplyDocked] edge={edge} barSizeScaled={barSizeScaled} " +
-                $"monitorScale={targetMonitor.scale} windowDpi={winDpi} " +
-                $"MonitorRect=({targetMonitor.MonitorRect.left},{targetMonitor.MonitorRect.top})-" +
-                $"({targetMonitor.MonitorRect.right},{targetMonitor.MonitorRect.bottom}) " +
-                $"WorkRect=({targetMonitor.WorkRect.left},{targetMonitor.WorkRect.top})-" +
-                $"({targetMonitor.WorkRect.right},{targetMonitor.WorkRect.bottom})";
-            Debug.WriteLine(hdr);
-            SettingMethods.FileLog(hdr);
-
             var abd = new APPBARDATA();
             abd.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
             abd.hWnd = hWnd;
@@ -297,43 +287,28 @@ namespace AppAppBar3
             // proposal, and it does so asymmetrically for Left vs Right.
             abd.rc = targetMonitor.MonitorRect;
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
-            LogRect("pre-QUERYPOS", abd.rc);
 
             SHAppBarMessage((int)AppBarMessages.ABM_QUERYPOS, ref abd);
-            LogRect("post-QUERYPOS", abd.rc);
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             SHAppBarMessage((int)AppBarMessages.ABM_SETPOS, ref abd);
-            LogRect("post-SETPOS", abd.rc);
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
             style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
             SetWindowLong(hWnd, GWL_STYLE, style);
-            // SWP_FRAMECHANGED commits the style change and forces WM_NCCALCSIZE before the
-            // move — without this, the window can retain non-client metrics from the old
-            // (captioned/thick-framed) style and the final MoveWindow sizes the wrong frame.
+            // SWP_FRAMECHANGED commits the style change and forces WM_NCCALCSIZE before
+            // the move so the window doesn't retain non-client metrics from the old frame.
             SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 
-            int moveW = abd.rc.right - abd.rc.left;
-            int moveH = abd.rc.bottom - abd.rc.top;
-            string moveLine = $"[ApplyDocked] SetWindowPos({abd.rc.left},{abd.rc.top},{moveW},{moveH})";
-            Debug.WriteLine(moveLine);
-            SettingMethods.FileLog(moveLine);
             // SWP_NOSENDCHANGING skips WM_WINDOWPOSCHANGING, which WinUIEx.WindowEx was
-            // intercepting to clamp our width up to ~132 DIPs (its content/MinWidth floor).
-            if (!SetWindowPos(hWnd, IntPtr.Zero, abd.rc.left, abd.rc.top, moveW, moveH,
+            // intercepting to clamp our width to ~132 DIPs (its content/MinWidth floor).
+            if (!SetWindowPos(hWnd, IntPtr.Zero, abd.rc.left, abd.rc.top,
+                abd.rc.right - abd.rc.left, abd.rc.bottom - abd.rc.top,
                 SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOSENDCHANGING))
             {
                 LogWin32Error("SetWindowPos (docked)");
-            }
-
-            if (GetWindowRect(hWnd, out RECT actual))
-            {
-                string actualLine = $"[ApplyDocked] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left} h={actual.bottom - actual.top}";
-                Debug.WriteLine(actualLine);
-                SettingMethods.FileLog(actualLine);
             }
 
             SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
@@ -348,13 +323,6 @@ namespace AppAppBar3
                 case ABEdge.Top:    rc.bottom = rc.top + thickness; break;
                 case ABEdge.Bottom: rc.top    = rc.bottom - thickness; break;
             }
-        }
-
-        private static void LogRect(string label, RECT r)
-        {
-            string line = $"[ApplyDocked] {label} rc=({r.left},{r.top})-({r.right},{r.bottom}) w={r.right - r.left} h={r.bottom - r.top}";
-            Debug.WriteLine(line);
-            SettingMethods.FileLog(line);
         }
 
         private void ApplyAutohide(IntPtr hWnd, ABEdge edge, Monitor targetMonitor, int barSizeScaled)
@@ -435,25 +403,13 @@ namespace AppAppBar3
             SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 
-            int winDpiAh = GetDpiForWindow(hWnd);
-            string ahLine = $"[ApplyAutohide] edge={edge} barSizeScaled={barSizeScaled} scale={scale} windowDpi={winDpiAh} triggerPx={triggerPx} " +
-                $"shown=({shownRect.left},{shownRect.top})-({shownRect.right},{shownRect.bottom}) w={shownRect.right - shownRect.left} " +
-                $"hidden=({hiddenRect.left},{hiddenRect.top})-({hiddenRect.right},{hiddenRect.bottom}) w={hiddenRect.right - hiddenRect.left}";
-            Debug.WriteLine(ahLine);
-            SettingMethods.FileLog(ahLine);
-
+            // SWP_NOSENDCHANGING skips the same WinUIEx MinWidth clamp that ApplyDocked
+            // avoids — autohide sizes the window to barSizeScaled on Left/Right too.
             SetWindowPos(hWnd, HWND_TOPMOST,
                 hiddenRect.left, hiddenRect.top,
                 hiddenRect.right - hiddenRect.left,
                 hiddenRect.bottom - hiddenRect.top,
-                SWP_NOACTIVATE);
-
-            if (GetWindowRect(hWnd, out RECT actual))
-            {
-                string actualAh = $"[ApplyAutohide] actual GetWindowRect=({actual.left},{actual.top})-({actual.right},{actual.bottom}) w={actual.right - actual.left}";
-                Debug.WriteLine(actualAh);
-                SettingMethods.FileLog(actualAh);
-            }
+                SWP_NOACTIVATE | SWP_NOSENDCHANGING);
             autohideState = AutohideState.Hidden;
             cursorLeftShownAt = DateTime.MaxValue;
 
@@ -597,14 +553,14 @@ namespace AppAppBar3
             int w = from.right - from.left;
             int h = from.bottom - from.top;
             var hWnd = WindowNative.GetWindowHandle(this);
-            SetWindowPos(hWnd, HWND_TOPMOST, x, y, w, h, SWP_NOACTIVATE);
+            SetWindowPos(hWnd, HWND_TOPMOST, x, y, w, h, SWP_NOACTIVATE | SWP_NOSENDCHANGING);
         }
 
         private void SnapTo(RECT r)
         {
             var hWnd = WindowNative.GetWindowHandle(this);
             SetWindowPos(hWnd, HWND_TOPMOST, r.left, r.top,
-                r.right - r.left, r.bottom - r.top, SWP_NOACTIVATE);
+                r.right - r.left, r.bottom - r.top, SWP_NOACTIVATE | SWP_NOSENDCHANGING);
         }
 
         private static bool PointInRect(POINT p, RECT r)

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -22,7 +22,6 @@ using WinUIEx;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Windows.Data.Xml.Dom;
-using Microsoft.Win32;
 
 
 

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -155,18 +155,12 @@ namespace AppAppBar3
 
                 //check if settings file exists
 
-                if (!Windows.Storage.ApplicationData.Current.LocalSettings.Values.ContainsKey("edge"))
+                if (loadSettings("edge") == null)
                 {
                     SettingMethods.setDefaultValues();
-                    edgeMonitor.SelectedItem = (ABEdge)loadSettings("edge");
-                    cbMonitor.SelectedItem = (string)loadSettings("monitor");
                 }
-               
-                else
-                {
-                    edgeMonitor.SelectedItem = (ABEdge)loadSettings("edge");
-                    cbMonitor.SelectedItem = (string)loadSettings("monitor");
-                }
+                edgeMonitor.SelectedItem = (ABEdge)loadSettings("edge");
+                cbMonitor.SelectedItem = (string)loadSettings("monitor");
                
                 
                 Debug.WriteLine("Window activated edge from settings " + (ABEdge)loadSettings("edge"));

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -623,6 +623,32 @@ namespace AppAppBar3
         }
 
 #region shortcuts
+        // Late-bound COM (WScript.Shell) to resolve .lnk → target path. Avoids a
+        // type-library-imported COMReference, which tlbimp can't process under
+        // `dotnet publish` (the .NET Core MSBuild — see MSB4803).
+        private static string ResolveShortcutTarget(string lnkPath)
+        {
+            Type shellType = Type.GetTypeFromProgID("WScript.Shell");
+            if (shellType == null) return null;
+            dynamic shell = null, shortcut = null;
+            try
+            {
+                shell = Activator.CreateInstance(shellType);
+                shortcut = shell.CreateShortcut(lnkPath);
+                return (string)shortcut.TargetPath;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("ResolveShortcutTarget failed: " + ex.Message);
+                return null;
+            }
+            finally
+            {
+                if (shortcut != null) Marshal.FinalReleaseComObject(shortcut);
+                if (shell != null) Marshal.FinalReleaseComObject(shell);
+            }
+        }
+
         private async void loadShortCuts()
         {
             var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\shortcuts.txt";
@@ -671,9 +697,7 @@ namespace AppAppBar3
                 Debug.WriteLine("File Type = " + type);
                 if (type == ".lnk")
                 {
-                    IWshRuntimeLibrary.IWshShell wsh = new IWshRuntimeLibrary.WshShellClass();
-                    IWshRuntimeLibrary.IWshShortcut sc = (IWshRuntimeLibrary.IWshShortcut)wsh.CreateShortcut(path);
-                    path = sc.TargetPath;
+                    path = ResolveShortcutTarget(path) ?? path;
                 }
                 await createShortCut(file, path);
                 try

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -114,7 +114,7 @@ namespace AppAppBar3
         private DispatcherTimer autohideTimer;
         private const int AutohideAnimMs = 200;
         private const int AutohideHideDebounceMs = 300;
-        private const int AutohideTriggerPx = 2;
+        private const int AutohideTriggerPxUnscaled = 2;
         public MainWindow()
         {
          
@@ -254,7 +254,7 @@ namespace AppAppBar3
 
             int theBarSize = (loadSettings("bar_size") as int?) ?? 50;
             double scaleFactor = targetMonitor.scale > 0 ? targetMonitor.scale : 1.0;
-            int barSizeScaled = (int)(theBarSize * scaleFactor);
+            int barSizeScaled = (int)Math.Round(theBarSize * scaleFactor);
 
             if (!autoHideEnabled)
             {
@@ -274,23 +274,19 @@ namespace AppAppBar3
             abd.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
             abd.hWnd = hWnd;
             abd.uEdge = (int)edge;
-            abd.rc.top = targetMonitor.WorkRect.top;
-            abd.rc.bottom = targetMonitor.WorkRect.bottom;
-            abd.rc.left = targetMonitor.WorkRect.left;
-            abd.rc.right = targetMonitor.WorkRect.right;
 
-            // Query the system for an approved size and position.
+            // Start with the full monitor rect and pre-apply the desired thickness on the
+            // dock side before ABM_QUERYPOS — this matches the MSDN AppBar sample. Passing
+            // the full work area as the proposed rect makes the shell shrink an oversized
+            // proposal, and it does so asymmetrically for Left vs Right.
+            abd.rc = targetMonitor.MonitorRect;
+            ApplyThickness(ref abd.rc, edge, barSizeScaled);
+
             SHAppBarMessage((int)AppBarMessages.ABM_QUERYPOS, ref abd);
-
-            switch (abd.uEdge)
-            {
-                case (int)ABEdge.Left:   abd.rc.right  = abd.rc.left + barSizeScaled; break;
-                case (int)ABEdge.Right:  abd.rc.left   = abd.rc.right - barSizeScaled; break;
-                case (int)ABEdge.Top:    abd.rc.bottom = abd.rc.top + barSizeScaled; break;
-                case (int)ABEdge.Bottom: abd.rc.top    = abd.rc.bottom - barSizeScaled; break;
-            }
+            ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             SHAppBarMessage((int)AppBarMessages.ABM_SETPOS, ref abd);
+            ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
             IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
             style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
@@ -303,6 +299,17 @@ namespace AppAppBar3
             }
 
             SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
+        }
+
+        private static void ApplyThickness(ref RECT rc, ABEdge edge, int thickness)
+        {
+            switch (edge)
+            {
+                case ABEdge.Left:   rc.right  = rc.left + thickness; break;
+                case ABEdge.Right:  rc.left   = rc.right - thickness; break;
+                case ABEdge.Top:    rc.bottom = rc.top + thickness; break;
+                case ABEdge.Bottom: rc.top    = rc.bottom - thickness; break;
+            }
         }
 
         private void ApplyAutohide(IntPtr hWnd, ABEdge edge, Monitor targetMonitor, int barSizeScaled)
@@ -342,23 +349,28 @@ namespace AppAppBar3
                 case ABEdge.Bottom: shownRect.top    = shownRect.bottom - barSizeScaled; break;
             }
 
+            // Scale the trigger strip by monitor DPI so the hit area stays usable on
+            // high-DPI displays (2 physical px is nearly invisible at 200%).
+            double scale = targetMonitor.scale > 0 ? targetMonitor.scale : 1.0;
+            int triggerPx = Math.Max(1, (int)Math.Round(AutohideTriggerPxUnscaled * scale));
+
             hiddenRect = shownRect;
             switch (edge)
             {
                 case ABEdge.Left:
-                    hiddenRect.left  = mon.left - barSizeScaled + AutohideTriggerPx;
+                    hiddenRect.left  = mon.left - barSizeScaled + triggerPx;
                     hiddenRect.right = hiddenRect.left + barSizeScaled;
                     break;
                 case ABEdge.Right:
-                    hiddenRect.right = mon.right + barSizeScaled - AutohideTriggerPx;
+                    hiddenRect.right = mon.right + barSizeScaled - triggerPx;
                     hiddenRect.left  = hiddenRect.right - barSizeScaled;
                     break;
                 case ABEdge.Top:
-                    hiddenRect.top    = mon.top - barSizeScaled + AutohideTriggerPx;
+                    hiddenRect.top    = mon.top - barSizeScaled + triggerPx;
                     hiddenRect.bottom = hiddenRect.top + barSizeScaled;
                     break;
                 case ABEdge.Bottom:
-                    hiddenRect.bottom = mon.bottom + barSizeScaled - AutohideTriggerPx;
+                    hiddenRect.bottom = mon.bottom + barSizeScaled - triggerPx;
                     hiddenRect.top    = hiddenRect.bottom - barSizeScaled;
                     break;
             }
@@ -366,10 +378,10 @@ namespace AppAppBar3
             triggerRect = mon;
             switch (edge)
             {
-                case ABEdge.Left:   triggerRect.right  = mon.left + AutohideTriggerPx; break;
-                case ABEdge.Right:  triggerRect.left   = mon.right - AutohideTriggerPx; break;
-                case ABEdge.Top:    triggerRect.bottom = mon.top + AutohideTriggerPx; break;
-                case ABEdge.Bottom: triggerRect.top    = mon.bottom - AutohideTriggerPx; break;
+                case ABEdge.Left:   triggerRect.right  = mon.left + triggerPx; break;
+                case ABEdge.Right:  triggerRect.left   = mon.right - triggerPx; break;
+                case ABEdge.Top:    triggerRect.bottom = mon.top + triggerPx; break;
+                case ABEdge.Bottom: triggerRect.top    = mon.bottom - triggerPx; break;
             }
 
             IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
@@ -939,79 +951,57 @@ namespace AppAppBar3
 
         void DockToAppBar(Window webW)
         {
-            //IntPtr whWnd = WindowNative.GetWindowHandle(webW);
-            // WindowId windowId = Win32Interop.GetWindowIdFromWindow(whWnd);
-            // var wappWindow = AppWindow.GetFromWindowId(windowId);
             var wappWindow = webW.GetAppWindow();
+            bool isSettings = wappWindow.Title == "Settings";
 
-            int newWindowWidth = 0;// = screenWidth;
-            int newWindowHeight = 0;// = screenHeight - 100;
-            int newWindowX = 0;//= (int)(taskbarRect.X);
-            int newWindowY = 0;//= 100;
-            foreach (var monitor in monitorInfo)
-                if (monitor.MonitorName == cbMonitor.SelectedItem as string)
-                {
+            Monitor mon = null;
+            foreach (var m in monitorInfo)
+                if (m.MonitorName == cbMonitor.SelectedItem as string) { mon = m; break; }
+            if (mon == null) return;
 
-                var workarea = monitor.WorkRect;
-            //var workarea = getMonitorWorkRect(cbMonitor.SelectedItem as string);
+            int x, y, w, h;
 
-            if (Edge == ABEdge.Top)
+            if (isSettings)
             {
-                newWindowWidth = workarea.right - workarea.left;
-                newWindowHeight = workarea.bottom;
-                newWindowX = workarea.left;
-                newWindowY = workarea.top;
-                if (wappWindow.Title == "Settings")
-                {
-                    newWindowWidth = wappWindow.Size.Width;
-                    newWindowHeight = wappWindow.Size.Height;
-                    newWindowX = (int)((appWindow.Size.Width / 2) - (wappWindow.Size.Width / 2));
-                }
+                // Settings docks adjacent to the main appbar — it keeps its own size and
+                // sits just outside the bar's dock edge, centered along the bar's length.
+                w = wappWindow.Size.Width;
+                h = wappWindow.Size.Height;
+                var abPos = appWindow.Position;
+                var abSize = appWindow.Size;
 
-            }
-            else if (Edge == ABEdge.Bottom)
-            {
-                newWindowWidth = workarea.right - workarea.left;
-                newWindowHeight = workarea.bottom;
-                newWindowX = workarea.left;
-                newWindowY = workarea.top;
-                if (wappWindow.Title == "Settings")
+                switch (Edge)
                 {
-                    newWindowWidth = wappWindow.Size.Width;
-                    newWindowHeight = wappWindow.Size.Height;
-                    newWindowX = (int)((appWindow.Size.Width / 2) - (wappWindow.Size.Width / 2));
-                }
-            }
-            else if (Edge == ABEdge.Left)
-            {
-                newWindowWidth = workarea.right - workarea.left;
-                newWindowHeight = workarea.bottom;
-                newWindowX = workarea.left;
-                newWindowY = workarea.top;
-                if (wappWindow.Title == "Settings")
-                {
-                    newWindowWidth = wappWindow.Size.Width;
-                    newWindowHeight = wappWindow.Size.Height;
-                    newWindowY = (int)((appWindow.Size.Height / 2) - (wappWindow.Size.Height / 2));
-                }
-
-            }
-            else if (Edge == ABEdge.Right)
-            {
-                newWindowWidth = workarea.right - workarea.left;
-                newWindowHeight = workarea.bottom;
-                newWindowX = workarea.left;
-                newWindowY = workarea.top;
-                if (wappWindow.Title == "Settings")
-                {
-                    newWindowWidth = wappWindow.Size.Width;
-                    newWindowHeight = wappWindow.Size.Height;
-                    newWindowY = (int)((appWindow.Size.Height / 2) - (wappWindow.Size.Height / 2));
+                    case ABEdge.Top:
+                        x = abPos.X + (abSize.Width - w) / 2;
+                        y = abPos.Y + abSize.Height;
+                        break;
+                    case ABEdge.Bottom:
+                        x = abPos.X + (abSize.Width - w) / 2;
+                        y = abPos.Y - h;
+                        break;
+                    case ABEdge.Left:
+                        x = abPos.X + abSize.Width;
+                        y = abPos.Y + (abSize.Height - h) / 2;
+                        break;
+                    case ABEdge.Right:
+                    default:
+                        x = abPos.X - w;
+                        y = abPos.Y + (abSize.Height - h) / 2;
+                        break;
                 }
             }
+            else
+            {
+                // Web window fills the work area of the selected monitor.
+                var workarea = mon.WorkRect;
+                x = workarea.left;
+                y = workarea.top;
+                w = workarea.right - workarea.left;
+                h = workarea.bottom - workarea.top;
+            }
 
-            webW.AppWindow.MoveAndResize(new Windows.Graphics.RectInt32(newWindowX, newWindowY, newWindowWidth, newWindowHeight));
-        }
+            webW.AppWindow.MoveAndResize(new Windows.Graphics.RectInt32(x, y, w, h));
         }
 
         private void appbarWindow_Closed(object sender, WindowEventArgs args)

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -96,7 +96,26 @@ namespace AppAppBar3
         public List<Monitor> monitorInfo;
 
         private int uCallBack;
+        private int taskbarCreatedMsg;
         private AppWindow appWindow;
+
+        // --- Autohide state ---
+        private enum AutohideState { Hidden, Showing, Shown, Hiding }
+        private bool autoHideEnabled;
+        private bool autohideRegistered;
+        private ABEdge autohideRegisteredEdge;
+        private RECT autohideMonitorRect;
+        private RECT shownRect;
+        private RECT hiddenRect;
+        private RECT triggerRect;
+        private AutohideState autohideState = AutohideState.Hidden;
+        private DateTime animationStart;
+        private DateTime cursorLeftShownAt = DateTime.MaxValue;
+        private bool fullscreenAppActive;
+        private DispatcherTimer autohideTimer;
+        private const int AutohideAnimMs = 200;
+        private const int AutohideHideDebounceMs = 300;
+        private const int AutohideTriggerPx = 2;
         public MainWindow()
         {
          
@@ -109,6 +128,7 @@ namespace AppAppBar3
             edgeMonitor.DataContext = this;
             monitor = new WindowMessageMonitor(this);
             monitor.WindowMessageReceived += OnWindowMessageReceived;
+            taskbarCreatedMsg = RegisterWindowMessage("TaskbarCreated");
             edgeMonitor.ItemsSource = Enum.GetValues(typeof(ABEdge));
         }
        
@@ -161,7 +181,7 @@ namespace AppAppBar3
                 // Ensure we only register the app bar once
                 if (args.WindowActivationState != WindowActivationState.Deactivated)
                 {
-                    RegisterBar((ABEdge)loadSettings("edge"), (string)loadSettings("monitor"));
+                    RegisterAppBar((ABEdge)loadSettings("edge"), (string)loadSettings("monitor"));
 
                     // Optionally, unsubscribe from Activated event after first activation
                     this.Activated -= OnActivated;
@@ -189,203 +209,405 @@ namespace AppAppBar3
 
        
 
-        APPBARDATA abd;
-
-        private void RegisterBar(ABEdge edge, string selectedMonitor)
+        private void RegisterAppBar(ABEdge edge, string selectedMonitor)
         {
+            if (fBarRegistered) return;
+
             var hWnd = WindowNative.GetWindowHandle(this);
-            APPBARDATA abd = new APPBARDATA();
+            var abd = new APPBARDATA();
             abd.cbSize = Marshal.SizeOf(abd);
             abd.hWnd = hWnd;
-            if (!fBarRegistered)
+            uCallBack = RegisterWindowMessage("AppBarMessage");
+            abd.uCallbackMessage = uCallBack;
+
+            IntPtr result = SHAppBarMessage((int)AppBarMessages.ABM_NEW, ref abd);
+            if (result == IntPtr.Zero)
             {
-                uCallBack = RegisterWindowMessage("AppBarMessage");
-                abd.uCallbackMessage = uCallBack;
+                Debug.WriteLine("ABM_NEW failed — shell rejected appbar registration.");
+                return;
+            }
+            fBarRegistered = true;
+            ABSetPos(edge, selectedMonitor);
+        }
 
-                SHAppBarMessage((int)AppBarMessages.ABM_NEW, ref abd);
-                fBarRegistered = true;
-                //remove corner radius by removing border and caption, remove title bar, remove from zorder, do not activate
-                //IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
-                //style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME | SWP_NOZORDER | SWP_NOACTIVATE));
+        private void UnregisterAppBar()
+        {
+            StopAutohideTimer();
+            UnregisterAutohideIfNeeded();
+            if (!fBarRegistered) return;
 
-                //SetWindowLong(hWnd, GWL_STYLE, style);
-                SHAppBarMessage((int)AppBarMessages.ABM_ACTIVATE, ref abd);
-                ABSetPos(edge,selectedMonitor);
-                
+            var hWnd = WindowNative.GetWindowHandle(this);
+            var abd = new APPBARDATA();
+            abd.cbSize = Marshal.SizeOf(abd);
+            abd.hWnd = hWnd;
+            SHAppBarMessage((int)AppBarMessages.ABM_REMOVE, ref abd);
+            fBarRegistered = false;
+        }
+        private void ABSetPos(ABEdge edge, string selectedMonitor)
+        {
+            Debug.WriteLine("the selected monitor in ABSETPOS " + selectedMonitor);
+
+            autoHideEnabled = (loadSettings("autohide") as bool?) ?? false;
+
+            // Release any prior autohide registration before reconfiguring.
+            UnregisterAutohideIfNeeded();
+
+            var hWnd = WindowNative.GetWindowHandle(this);
+
+            Monitor targetMonitor = null;
+            foreach (var m in MonitorList)
+                if (m.MonitorName == selectedMonitor) { targetMonitor = m; break; }
+            if (targetMonitor == null) return;
+
+            int theBarSize = (loadSettings("bar_size") as int?) ?? 50;
+            double scaleFactor = targetMonitor.scale > 0 ? targetMonitor.scale : 1.0;
+            int barSizeScaled = (int)(theBarSize * scaleFactor);
+
+            if (!autoHideEnabled)
+            {
+                ApplyDocked(hWnd, edge, targetMonitor, barSizeScaled);
             }
             else
             {
-                
-                SHAppBarMessage((int)AppBarMessages.ABM_REMOVE, ref abd);
-                fBarRegistered = false;
+                ApplyAutohide(hWnd, edge, targetMonitor, barSizeScaled);
             }
         }
-       /* private const int ABS_AUTOHIDE = 0x1;
-        private const int ABS_ALWAYSONTOP = 0x2;
-        private const int HWND_TOPMOST = -1;
-        private const int HWND_NOTOPMOST = -2;*/
-      //  private const int SWP_NOMOVE = 0x0002;
-      //  private const int SWP_NOSIZE = 0x0001;
-        const uint SWP_NOZORDER = 0x0004;
-        const uint SWP_NOACTIVATE = 0x0010;
-        //const uint WS_EX_TOOLWINDOW = 0x00000080;
-       // const uint WS_VISIBLE = 0x10000000;
 
-       // public const int SWP_ASYNCWINDOWPOS = 0x4000;
-        private void ABSetPos(ABEdge edge, string selectedMonitor)
+        private void ApplyDocked(IntPtr hWnd, ABEdge edge, Monitor targetMonitor, int barSizeScaled)
         {
-            
+            StopAutohideTimer();
 
-            Debug.WriteLine("the selected monitor in ABSETPOS " + selectedMonitor);
-            var hWnd = WindowNative.GetWindowHandle(this);
-            abd = new APPBARDATA();
+            var abd = new APPBARDATA();
             abd.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
             abd.hWnd = hWnd;
             abd.uEdge = (int)edge;
-            //monitorInfo = GetMonitorsInfo();
-            double scaleFactor =1.5;
-           // MonitorList = null;
-           // MonitorList = new ObservableCollection<Monitor>(GetMonitorsInfo());
-            foreach (var monitor in MonitorList)
-            {
-                
-                if (monitor.MonitorName == selectedMonitor)
-                {
-                    Debug.WriteLine("wrc right " + monitor.WorkRect.right);
-                    abd.rc.top = monitor.WorkRect.top;
-                    abd.rc.bottom = monitor.WorkRect.bottom;
-                    abd.rc.left = monitor.WorkRect.left;
-                    abd.rc.right = monitor.WorkRect.right;
-                    //scaleFactor = monitor.scale;
-                    scaleFactor = GetScale(monitor.MonitorName);
+            abd.rc.top = targetMonitor.WorkRect.top;
+            abd.rc.bottom = targetMonitor.WorkRect.bottom;
+            abd.rc.left = targetMonitor.WorkRect.left;
+            abd.rc.right = targetMonitor.WorkRect.right;
 
-           // var wrc = MonitorHelper.getMonitorRECT(selectedMonitor);
-
-
-                    // Query the system for an approved size and position. 
-
+            // Query the system for an approved size and position.
             SHAppBarMessage((int)AppBarMessages.ABM_QUERYPOS, ref abd);
 
-            Debug.WriteLine("********Scale Factor**************** " + GetScale(monitor.MonitorName));
-            // Adjust the rectangle, depending on the edge to which the 
-            // appbar is anchored. 
-            // Eventhough Winui 3 is set to auto scale the Win32 Appbar does not.  we use GetScale(monitor)
-            // to get this done.
-            int theBarSize;
-            if (SettingMethods.loadSettings("bar_size") != null)
+            switch (abd.uEdge)
             {
-                theBarSize = (int)SettingMethods.loadSettings("bar_size");
+                case (int)ABEdge.Left:   abd.rc.right  = abd.rc.left + barSizeScaled; break;
+                case (int)ABEdge.Right:  abd.rc.left   = abd.rc.right - barSizeScaled; break;
+                case (int)ABEdge.Top:    abd.rc.bottom = abd.rc.top + barSizeScaled; break;
+                case (int)ABEdge.Bottom: abd.rc.top    = abd.rc.bottom - barSizeScaled; break;
             }
-            else
-            {
-                theBarSize = 50;
-            }
-                
 
-            switch (abd.uEdge) 
-             {
-                 case (int)ABEdge.Left:
-                     abd.rc.right = (int)(abd.rc.left + (theBarSize * scaleFactor));
-                    break;
-                 case (int)ABEdge.Right:
-                    abd.rc.left = (int)(abd.rc.right - (theBarSize * scaleFactor));
-                    Debug.WriteLine("the left side " + abd.rc.left +" the right side "+abd.rc.right);
-                     break;
-                 case (int)ABEdge.Top:
-                     abd.rc.bottom = (int)(abd.rc.top + (theBarSize * scaleFactor));
-                    break;
-                 case (int)ABEdge.Bottom:
-                    abd.rc.top = (int)(abd.rc.bottom - (theBarSize * scaleFactor));
-                    break;
-             }
-
-            // Pass the final bounding rectangle to the system. 
-            /***********************Autohide not working******************************/
-          //  abd.lParam = ABS_ALWAYSONTOP;
-           // abd.lParam = (IntPtr)ABS_AUTOHIDE;
-           // IntPtr state = SHAppBarMessage((int)AppBarMessages.ABM_SETSTATE, ref abd); // Set to autohide
-            
-           // Debug.WriteLine("Appbar state " + state);
             SHAppBarMessage((int)AppBarMessages.ABM_SETPOS, ref abd);
-            Debug.WriteLine("abd right "+abd.rc.right);
-            Debug.WriteLine("abd Left " + abd.rc.left);
-            Debug.WriteLine("abd top " + abd.rc.top);
-            Debug.WriteLine("abd bottom " + abd.rc.bottom);
-            
-            Debug.WriteLine("Window width " + (abd.rc.right - abd.rc.left));
-                    IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
-                    style = (IntPtr)(style.ToInt64() & ~(WS_THICKFRAME | SWP_NOZORDER | SWP_NOACTIVATE));
-                    SetWindowLong(hWnd, GWL_STYLE, style);
-                    //appWindow.MoveAndResize(new Windows.Graphics.RectInt32(abd.rc.left, abd.rc.top, (abd.rc.right - abd.rc.left), (abd.rc.bottom - abd.rc.top)));
-                    // Move and size the appbar so that it conforms to the bounding rectangle passed to the system. 
-                    // HwndExtensions.SetWindowSize(hWnd, (abd.rc.right - abd.rc.left), (abd.rc.bottom - abd.rc.top));
-                    bool success = MoveWindow(hWnd, abd.rc.left, abd.rc.top, (abd.rc.right - abd.rc.left), (abd.rc.bottom - abd.rc.top), true);
-                    //remove corner radius by removing border and caption, remove title bar, remove from zorder, do not activate
-                    //IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
-                    style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME | SWP_NOZORDER | SWP_NOACTIVATE));
-                    SetWindowLong(hWnd, GWL_STYLE, style);
-                    // MoveWindow(hWnd, abd.rc.left, abd.rc.top, (abd.rc.right - abd.rc.left), (abd.rc.bottom - abd.rc.top), true);
 
-                    Debug.WriteLine("Did we sucessed with resize and move *1* ? " + success);
-           // bool success2 = MoveWindow(hWnd, abd.rc.left, abd.rc.top, (abd.rc.right - abd.rc.left), (abd.rc.bottom - abd.rc.top), true);
-            //Debug.WriteLine("Did we sucessed with resize and move *2* ? " + success2);
-           // HwndExtensions.SetWindowPositionAndSize(hWnd, abd.rc.left, abd.rc.top, (abd.rc.right - abd.rc.left), (abd.rc.bottom - abd.rc.top));
-            //SetWindowPos(hWnd, (IntPtr)HWND_TOPMOST, abd.rc.left, abd.rc.top, (abd.rc.right - abd.rc.left), (abd.rc.bottom - abd.rc.top), SWP_ASYNCWINDOWPOS);
-            //appWindow.Show();
+            IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
+            style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
+            SetWindowLong(hWnd, GWL_STYLE, style);
+
+            if (!MoveWindow(hWnd, abd.rc.left, abd.rc.top,
+                abd.rc.right - abd.rc.left, abd.rc.bottom - abd.rc.top, true))
+            {
+                LogWin32Error("MoveWindow (docked)");
+            }
 
             SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
+        }
+
+        private void ApplyAutohide(IntPtr hWnd, ABEdge edge, Monitor targetMonitor, int barSizeScaled)
+        {
+            // Release any docked work-area reservation that may exist from a prior mode.
+            ReleaseDockedReservation(hWnd, edge);
+
+            var mon = targetMonitor.MonitorRect;
+
+            // Register as an autohide appbar on the chosen edge of this monitor.
+            var regAbd = new APPBARDATA();
+            regAbd.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
+            regAbd.hWnd = hWnd;
+            regAbd.uEdge = (int)edge;
+            regAbd.rc = mon;
+            regAbd.lParam = (IntPtr)1;
+            IntPtr result = SHAppBarMessage((int)AppBarMessages.ABM_SETAUTOHIDEBAREX, ref regAbd);
+            if (result == IntPtr.Zero)
+            {
+                Debug.WriteLine("ABM_SETAUTOHIDEBAREX failed — edge already owned (e.g. Windows taskbar autohide). Falling back to docked mode.");
+                autoHideEnabled = false;
+                saveSetting("autohide", false);
+                ApplyDocked(hWnd, edge, targetMonitor, barSizeScaled);
+                return;
+            }
+            autohideRegistered = true;
+            autohideRegisteredEdge = edge;
+            autohideMonitorRect = mon;
+
+            // Compute shown / hidden / trigger rects in physical pixels.
+            shownRect = mon;
+            switch (edge)
+            {
+                case ABEdge.Left:   shownRect.right  = shownRect.left + barSizeScaled; break;
+                case ABEdge.Right:  shownRect.left   = shownRect.right - barSizeScaled; break;
+                case ABEdge.Top:    shownRect.bottom = shownRect.top + barSizeScaled; break;
+                case ABEdge.Bottom: shownRect.top    = shownRect.bottom - barSizeScaled; break;
+            }
+
+            hiddenRect = shownRect;
+            switch (edge)
+            {
+                case ABEdge.Left:
+                    hiddenRect.left  = mon.left - barSizeScaled + AutohideTriggerPx;
+                    hiddenRect.right = hiddenRect.left + barSizeScaled;
+                    break;
+                case ABEdge.Right:
+                    hiddenRect.right = mon.right + barSizeScaled - AutohideTriggerPx;
+                    hiddenRect.left  = hiddenRect.right - barSizeScaled;
+                    break;
+                case ABEdge.Top:
+                    hiddenRect.top    = mon.top - barSizeScaled + AutohideTriggerPx;
+                    hiddenRect.bottom = hiddenRect.top + barSizeScaled;
+                    break;
+                case ABEdge.Bottom:
+                    hiddenRect.bottom = mon.bottom + barSizeScaled - AutohideTriggerPx;
+                    hiddenRect.top    = hiddenRect.bottom - barSizeScaled;
+                    break;
+            }
+
+            triggerRect = mon;
+            switch (edge)
+            {
+                case ABEdge.Left:   triggerRect.right  = mon.left + AutohideTriggerPx; break;
+                case ABEdge.Right:  triggerRect.left   = mon.right - AutohideTriggerPx; break;
+                case ABEdge.Top:    triggerRect.bottom = mon.top + AutohideTriggerPx; break;
+                case ABEdge.Bottom: triggerRect.top    = mon.bottom - AutohideTriggerPx; break;
+            }
+
+            IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
+            style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
+            SetWindowLong(hWnd, GWL_STYLE, style);
+
+            SetWindowPos(hWnd, HWND_TOPMOST,
+                hiddenRect.left, hiddenRect.top,
+                hiddenRect.right - hiddenRect.left,
+                hiddenRect.bottom - hiddenRect.top,
+                SWP_NOACTIVATE);
+            autohideState = AutohideState.Hidden;
+            cursorLeftShownAt = DateTime.MaxValue;
+
+            StartAutohideTimer();
+        }
+
+        private void ReleaseDockedReservation(IntPtr hWnd, ABEdge edge)
+        {
+            var a = new APPBARDATA();
+            a.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
+            a.hWnd = hWnd;
+            a.uEdge = (int)edge;
+            // Zero rect tells the shell our docked appbar reserves no work area.
+            a.rc.left = 0; a.rc.top = 0; a.rc.right = 0; a.rc.bottom = 0;
+            SHAppBarMessage((int)AppBarMessages.ABM_SETPOS, ref a);
+        }
+
+        private void UnregisterAutohideIfNeeded()
+        {
+            if (!autohideRegistered) return;
+            StopAutohideTimer();
+            var hWnd = WindowNative.GetWindowHandle(this);
+            var a = new APPBARDATA();
+            a.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
+            a.hWnd = hWnd;
+            a.uEdge = (int)autohideRegisteredEdge;
+            a.rc = autohideMonitorRect;
+            a.lParam = IntPtr.Zero;
+            SHAppBarMessage((int)AppBarMessages.ABM_SETAUTOHIDEBAREX, ref a);
+            autohideRegistered = false;
+        }
+
+        // 16 ms (~60 fps) while animating, 100 ms while idle — the idle rate only
+        // needs to be tight enough to feel responsive when the cursor hits the trigger.
+        private const int AutohideIdleTickMs   = 100;
+        private const int AutohideActiveTickMs = 16;
+
+        private void StartAutohideTimer()
+        {
+            if (autohideTimer == null)
+            {
+                autohideTimer = new DispatcherTimer();
+                autohideTimer.Tick += AutohideTick;
+            }
+            SetAutohideTimerInterval(AutohideIdleTickMs);
+            autohideTimer.Start();
+        }
+
+        private void StopAutohideTimer()
+        {
+            autohideTimer?.Stop();
+        }
+
+        private void SetAutohideTimerInterval(int ms)
+        {
+            if (autohideTimer == null) return;
+            var desired = TimeSpan.FromMilliseconds(ms);
+            if (autohideTimer.Interval != desired)
+                autohideTimer.Interval = desired;
+        }
+
+        private void AutohideTick(object sender, object e)
+        {
+            if (fullscreenAppActive)
+            {
+                if (autohideState != AutohideState.Hidden)
+                {
+                    SnapTo(hiddenRect);
+                    autohideState = AutohideState.Hidden;
+                }
+                SetAutohideTimerInterval(AutohideIdleTickMs);
+                return;
+            }
+
+            if (!GetCursorPos(out POINT p)) return;
+            var now = DateTime.UtcNow;
+            const double dur = AutohideAnimMs;
+
+            switch (autohideState)
+            {
+                case AutohideState.Hidden:
+                    if (PointInRect(p, triggerRect))
+                    {
+                        animationStart = now;
+                        autohideState = AutohideState.Showing;
+                        SetAutohideTimerInterval(AutohideActiveTickMs);
+                    }
+                    break;
+
+                case AutohideState.Showing:
+                {
+                    double t = Math.Min(1.0, (now - animationStart).TotalMilliseconds / dur);
+                    double eased = 1 - Math.Pow(1 - t, 2);
+                    ApplyInterpolatedRect(hiddenRect, shownRect, eased);
+                    if (t >= 1.0)
+                    {
+                        autohideState = AutohideState.Shown;
+                        cursorLeftShownAt = DateTime.MaxValue;
+                        SetAutohideTimerInterval(AutohideIdleTickMs);
+                    }
                     break;
                 }
 
+                case AutohideState.Shown:
+                    if (PointInRect(p, shownRect))
+                    {
+                        cursorLeftShownAt = DateTime.MaxValue;
+                    }
+                    else
+                    {
+                        if (cursorLeftShownAt == DateTime.MaxValue)
+                            cursorLeftShownAt = now;
+                        else if ((now - cursorLeftShownAt).TotalMilliseconds > AutohideHideDebounceMs)
+                        {
+                            animationStart = now;
+                            autohideState = AutohideState.Hiding;
+                            SetAutohideTimerInterval(AutohideActiveTickMs);
+                        }
+                    }
+                    break;
+
+                case AutohideState.Hiding:
+                {
+                    double t = Math.Min(1.0, (now - animationStart).TotalMilliseconds / dur);
+                    double eased = 1 - Math.Pow(1 - t, 2);
+                    ApplyInterpolatedRect(shownRect, hiddenRect, eased);
+                    if (t >= 1.0)
+                    {
+                        autohideState = AutohideState.Hidden;
+                        SetAutohideTimerInterval(AutohideIdleTickMs);
+                    }
+                    break;
+                }
             }
         }
+
+        private void ApplyInterpolatedRect(RECT from, RECT to, double t)
+        {
+            int x = (int)(from.left + (to.left - from.left) * t);
+            int y = (int)(from.top + (to.top - from.top) * t);
+            int w = from.right - from.left;
+            int h = from.bottom - from.top;
+            var hWnd = WindowNative.GetWindowHandle(this);
+            SetWindowPos(hWnd, HWND_TOPMOST, x, y, w, h, SWP_NOACTIVATE);
+        }
+
+        private void SnapTo(RECT r)
+        {
+            var hWnd = WindowNative.GetWindowHandle(this);
+            SetWindowPos(hWnd, HWND_TOPMOST, r.left, r.top,
+                r.right - r.left, r.bottom - r.top, SWP_NOACTIVATE);
+        }
+
+        private static bool PointInRect(POINT p, RECT r)
+            => p.x >= r.left && p.x < r.right && p.y >= r.top && p.y < r.bottom;
 
         /******************* OnWindowMessageReceived is WndProc****************/
         private void OnWindowMessageReceived(object sender, WindowMessageEventArgs e)
         {
-           // Debug.WriteLine("*************Message receieved********** " + e.Message.ToString());
-            const int WM_DISPLAYCHANGE = 7;
-
+            // AppBar callback notifications (WParam identifies which ABN_ this is).
             if (e.Message.MessageId == uCallBack)
             {
-                Debug.WriteLine("**!!*****Message Main Window receieved in callback**!!**** " + e.Message.ToString() +" "+e.Message.MessageId.ToString());
                 switch (e.Message.WParam)
                 {
-                     
-                    case (int)ABNotify.ABN_POSCHANGED: //arries when bar changes to different monitor
-                        Debug.WriteLine("*************Message receieved in callback********** " + e.Message.ToString());
-                      //  monitor.WindowMessageReceived -= OnWindowMessageReceived;
-                      relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
-                      //  monitor.WindowMessageReceived += OnWindowMessageReceived;
-
+                    case (int)ABNotify.ABN_POSCHANGED:
+                        relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
                         break;
 
+                    case (int)ABNotify.ABN_FULLSCREENAPP:
+                        fullscreenAppActive = (long)e.Message.LParam != 0;
+                        break;
+
+                    case (int)ABNotify.ABN_STATECHANGE:
+                        // System autohide/alwaystop state changed — no action needed for our bar.
+                        break;
                 }
+                return;
             }
+
+            // Explorer restart: re-register the appbar.
+            if (taskbarCreatedMsg != 0 && (int)e.Message.MessageId == taskbarCreatedMsg)
+            {
+                Debug.WriteLine("TaskbarCreated received — re-registering appbar.");
+                fBarRegistered = false;
+                autohideRegistered = false;
+                RegisterAppBar((ABEdge)loadSettings("edge"), (string)loadSettings("monitor"));
+                return;
+            }
+
             switch (e.Message.MessageId)
             {
-                case (int)AppBarMessages.ABM_WINDOWPOSCHANGED:
-                    Debug.WriteLine("window changed position changed notification " + e.Message.ToString());
-                    //relocateWindowLocation();
-                    SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
+                case WM_ACTIVATE:
+                    // The AppBar contract requires forwarding WM_ACTIVATE so the shell can manage z-order.
+                    if (fBarRegistered)
+                    {
+                        var a = new APPBARDATA();
+                        a.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
+                        a.hWnd = WindowNative.GetWindowHandle(this);
+                        SHAppBarMessage((int)AppBarMessages.ABM_ACTIVATE, ref a);
+                    }
                     break;
-            
-                
+
+                case WM_WINDOWPOSCHANGED:
+                    if (fBarRegistered)
+                    {
+                        var a = new APPBARDATA();
+                        a.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
+                        a.hWnd = WindowNative.GetWindowHandle(this);
+                        SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref a);
+                    }
+                    break;
+
                 case WM_DISPLAYCHANGE:
-                    monitor.WindowMessageReceived -= OnWindowMessageReceived;
-                    var seletedMon = (cbMonitor.SelectedItem as String);
-
-                    Debug.WriteLine("Monitor attached ");
+                    var selectedMon = cbMonitor.SelectedItem as string;
                     cbMonitor.SelectionChanged -= DisplayComboBox_SelectionChanged;
-                    //relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
-
-
-                    MonitorList = null;
                     MonitorList = new ObservableCollection<Monitor>(GetMonitorsInfo());
+                    cbMonitor.SelectedItem = selectedMon;
                     cbMonitor.SelectionChanged += DisplayComboBox_SelectionChanged;
-                    cbMonitor.SelectedItem = seletedMon;
-                    monitor.WindowMessageReceived += OnWindowMessageReceived;
-
+                    // Rebuild our registration on the current edge/monitor (may have been disconnected).
+                    if (fBarRegistered) relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
                     break;
             }
         }
@@ -409,20 +631,33 @@ namespace AppAppBar3
 #region shortcuts
         private async void loadShortCuts()
         {
+            var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\shortcuts.txt";
+            if (!System.IO.File.Exists(path)) return;
+
+            string[] lines;
             try
             {
-                using (StreamReader sr = new StreamReader(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\shortcuts.txt"))
-                    while (!sr.EndOfStream)
-                    {
-                        var exePath = sr.ReadLine();
-                        StorageFile file = await StorageFile.GetFileFromPathAsync(exePath);
-                        Debug.WriteLine("path of shortcut readline " + exePath + " " + file.FileType);
-                        await createShortCut(file, exePath);
-                    }
+                lines = System.IO.File.ReadAllLines(path);
             }
             catch (Exception error)
             {
-                Debug.WriteLine(error.Message);
+                Debug.WriteLine("Failed to read shortcuts.txt: " + error.Message);
+                return;
+            }
+
+            foreach (var exePath in lines)
+            {
+                if (string.IsNullOrWhiteSpace(exePath)) continue;
+                try
+                {
+                    StorageFile file = await StorageFile.GetFileFromPathAsync(exePath);
+                    await createShortCut(file, exePath);
+                }
+                catch (Exception error)
+                {
+                    // One bad entry (missing file, permission denied, etc.) shouldn't abort the rest.
+                    Debug.WriteLine($"Skipping shortcut '{exePath}': {error.Message}");
+                }
             }
         }
 
@@ -515,10 +750,6 @@ namespace AppAppBar3
             }
         }
         #endregion
-        private void UnregisterAppBar()
-        {
-            RegisterBar(ABEdge.Top, cbMonitor.SelectedItem as string);
-        }
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
@@ -564,7 +795,7 @@ namespace AppAppBar3
             {
                 webWindow.Close();
             }
-           
+
             UnregisterAppBar();
             this.Close();
         }
@@ -633,14 +864,8 @@ namespace AppAppBar3
 
         private void DisplayComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            edgeMonitor.SelectionChanged -= edgeComboBox_SelectionChanged;
-            Debug.WriteLine("Monitor selection changed");
             relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
-            edgeMonitor.SelectionChanged += edgeComboBox_SelectionChanged;
-            
             selectedItemsText = (cbMonitor.SelectedItem as String);
-               
-                Debug.WriteLine("Selected Monitor Text**********" + (cbMonitor.SelectedItem as string));
         }
 
 
@@ -774,15 +999,21 @@ namespace AppAppBar3
 
         private void appbarWindow_Closed(object sender, WindowEventArgs args)
         {
-            foreach(var window in OpenWindows)
+            // Safety net: ensure appbar/autohide registrations are released even if
+            // the window is closed via an OS-level action (not the Close button).
+            UnregisterAppBar();
+
+            if (monitor != null)
             {
-                if(window != null)
-                {
-                    window.Close();
-                }
-                
+                monitor.WindowMessageReceived -= OnWindowMessageReceived;
+                monitor.Dispose();
+                monitor = null;
             }
 
+            foreach (var window in OpenWindows)
+            {
+                if (window != null) window.Close();
+            }
         }
 
 

--- a/AppAppBar3/MonitorHelper.cs
+++ b/AppAppBar3/MonitorHelper.cs
@@ -25,41 +25,39 @@ namespace AppAppBar3
             List<Monitor> monitors = new List<Monitor>();
             MonitorEnumProc callback = (IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData) =>
             {
-                double monitorScale = 1;
-                uint dpiX;
-                uint dpiY;
-                
-                MONITORINFOEX mi = new MONITORINFOEX();
-                mi.cbSize = Marshal.SizeOf(mi);
-                bool success = GetMonitorInfo(hMonitor, ref mi);
-                if (success)
+                // Throwing inside a native callback is undefined behavior — log and continue.
+                try
                 {
-                    GetDpiForMonitor(hMonitor, DpiType.Effective, out dpiX, out dpiY);
+                    MONITORINFOEX mi = new MONITORINFOEX();
+                    mi.cbSize = Marshal.SizeOf(mi);
+                    if (!GetMonitorInfo(hMonitor, ref mi))
+                    {
+                        Debug.WriteLine("GetMonitorInfo failed: err=" + Marshal.GetLastWin32Error());
+                        return true;
+                    }
 
-                    if (dpiX > 96)
+                    double monitorScale = 1;
+                    if (GetDpiForMonitor(hMonitor, DpiType.Effective, out uint dpiX, out _) == IntPtr.Zero && dpiX > 96)
                         monitorScale = (double)dpiX / 96d;
 
-
-                    var monitor = new Monitor
+                    monitors.Add(new Monitor
                     {
                         MonitorName = mi.szDevice,
                         scale = monitorScale,
                         WorkRect = mi.rcWork,
                         MonitorRect = mi.rcMonitor,
-                    };
-
-                    monitors.Add(monitor);
-
+                    });
                 }
-                else
+                catch (Exception ex)
                 {
-                    throw new Win32Exception();
+                    Debug.WriteLine("Monitor enumeration entry failed: " + ex.Message);
                 }
 
                 return true; // Continue enumeration
             };
 
-            EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, callback, IntPtr.Zero);
+            if (!EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, callback, IntPtr.Zero))
+                Debug.WriteLine("EnumDisplayMonitors failed: err=" + Marshal.GetLastWin32Error());
 
             return monitors;
         }

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -132,11 +132,6 @@ namespace AppAppBar3
         public const uint SWP_FRAMECHANGED    = 0x0020;
         public const uint SWP_NOSENDCHANGING  = 0x0400;
 
-        [DllImport("user32.dll")]
-        public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
-
-        [DllImport("user32.dll")]
-        public static extern int GetDpiForWindow(IntPtr hWnd);
 
         // Standard Win32 window messages used by the AppBar contract.
         public const int WM_ACTIVATE         = 0x0006;

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -36,6 +36,9 @@ namespace AppAppBar3
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
+        [DllImport("user32.dll")]
+        public static extern bool GetCursorPos(out POINT lpPoint);
+
         [DllImport("Shcore.dll")]
         public static extern IntPtr GetDpiForMonitor([In] IntPtr hmonitor, [In] DpiType dpiType, [Out] out uint dpiX, [Out] out uint dpiY);
     
@@ -103,18 +106,43 @@ namespace AppAppBar3
         //data structure for setting autohide or show on taskbar
         public enum AppBarMessages : int
         {
-            ABM_NEW = 0,
-            ABM_REMOVE,
-            ABM_QUERYPOS,
-            ABM_SETPOS,
-            ABM_GETSTATE,
-            ABM_GETTASKBARPOS,
-            ABM_ACTIVATE,
-            ABM_GETAUTOHIDEBAR,
-            ABM_SETAUTOHIDEBAR,
-            ABM_WINDOWPOSCHANGED = 0x0047,
-            ABM_WINDOWPOSCHANGING = 0x0046,
-            ABM_SETSTATE
+            ABM_NEW              = 0x00,
+            ABM_REMOVE           = 0x01,
+            ABM_QUERYPOS         = 0x02,
+            ABM_SETPOS           = 0x03,
+            ABM_GETSTATE         = 0x04,
+            ABM_GETTASKBARPOS    = 0x05,
+            ABM_ACTIVATE         = 0x06,
+            ABM_GETAUTOHIDEBAR   = 0x07,
+            ABM_SETAUTOHIDEBAR   = 0x08,
+            ABM_WINDOWPOSCHANGED = 0x09,
+            ABM_SETSTATE         = 0x0A,
+            ABM_GETAUTOHIDEBAREX = 0x0B,
+            ABM_SETAUTOHIDEBAREX = 0x0C,
+        }
+
+        public const int ABS_AUTOHIDE    = 0x1;
+        public const int ABS_ALWAYSONTOP = 0x2;
+
+        public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
+        public const uint SWP_NOACTIVATE = 0x0010;
+        public const uint SWP_NOSIZE     = 0x0001;
+        public const uint SWP_NOZORDER   = 0x0004;
+
+        // Standard Win32 window messages used by the AppBar contract.
+        public const int WM_ACTIVATE         = 0x0006;
+        public const int WM_WINDOWPOSCHANGED = 0x0047;
+        public const int WM_DISPLAYCHANGE    = 0x007E;
+
+        /// <summary>
+        /// Logs a Win32 error from the last P/Invoke that used SetLastError=true.
+        /// Call immediately after the failing call; subsequent managed work can clobber the last-error TLS slot.
+        /// </summary>
+        public static void LogWin32Error(string context)
+        {
+            int err = Marshal.GetLastWin32Error();
+            if (err != 0)
+                System.Diagnostics.Debug.WriteLine($"[Win32] {context} failed: code={err} ({new System.ComponentModel.Win32Exception(err).Message})");
         }
         public enum ABNotify : int
         {

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -125,9 +125,14 @@ namespace AppAppBar3
         public const int ABS_ALWAYSONTOP = 0x2;
 
         public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
-        public const uint SWP_NOACTIVATE = 0x0010;
-        public const uint SWP_NOSIZE     = 0x0001;
-        public const uint SWP_NOZORDER   = 0x0004;
+        public const uint SWP_NOACTIVATE    = 0x0010;
+        public const uint SWP_NOSIZE        = 0x0001;
+        public const uint SWP_NOZORDER      = 0x0004;
+        public const uint SWP_NOMOVE        = 0x0002;
+        public const uint SWP_FRAMECHANGED  = 0x0020;
+
+        [DllImport("user32.dll")]
+        public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
         // Standard Win32 window messages used by the AppBar contract.
         public const int WM_ACTIVATE         = 0x0006;

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -125,11 +125,12 @@ namespace AppAppBar3
         public const int ABS_ALWAYSONTOP = 0x2;
 
         public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
-        public const uint SWP_NOACTIVATE    = 0x0010;
-        public const uint SWP_NOSIZE        = 0x0001;
-        public const uint SWP_NOZORDER      = 0x0004;
-        public const uint SWP_NOMOVE        = 0x0002;
-        public const uint SWP_FRAMECHANGED  = 0x0020;
+        public const uint SWP_NOACTIVATE      = 0x0010;
+        public const uint SWP_NOSIZE          = 0x0001;
+        public const uint SWP_NOZORDER        = 0x0004;
+        public const uint SWP_NOMOVE          = 0x0002;
+        public const uint SWP_FRAMECHANGED    = 0x0020;
+        public const uint SWP_NOSENDCHANGING  = 0x0400;
 
         [DllImport("user32.dll")]
         public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -134,6 +134,9 @@ namespace AppAppBar3
         [DllImport("user32.dll")]
         public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
+        [DllImport("user32.dll")]
+        public static extern int GetDpiForWindow(IntPtr hWnd);
+
         // Standard Win32 window messages used by the AppBar contract.
         public const int WM_ACTIVATE         = 0x0006;
         public const int WM_WINDOWPOSCHANGED = 0x0047;

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -98,5 +98,21 @@ namespace AppAppBar3
             try { _ = Windows.ApplicationModel.Package.Current; return true; }
             catch { return false; }
         }
+
+        // Simple file logger for diagnosing sizing/DPI issues. Appends to
+        // %LOCALAPPDATA%\AppAppBar3_debug.log. Failures are swallowed — this is best-effort.
+        private static readonly string DebugLogPath =
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                         "AppAppBar3_debug.log");
+
+        public static void FileLog(string message)
+        {
+            try
+            {
+                File.AppendAllText(DebugLogPath,
+                    DateTime.Now.ToString("HH:mm:ss.fff") + " " + message + Environment.NewLine);
+            }
+            catch { }
+        }
     }
 }

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -1,49 +1,102 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Windows.Storage;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
 
 namespace AppAppBar3
 {
+    // Cross-mode settings store: a JSON file in %LOCALAPPDATA%\AppAppBar3\settings.json.
+    // Works identically for packaged (MSIX) and unpackaged builds — Windows.Storage.ApplicationData
+    // throws in fully unpackaged apps, so we can't rely on it if we want a portable .exe.
     public static class SettingMethods
     {
-        static ApplicationDataContainer localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
+        private static readonly string SettingsDir =
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "AppAppBar3");
+        private static readonly string SettingsPath = Path.Combine(SettingsDir, "settings.json");
 
-       public static void setDefaultValues()
+        private static Dictionary<string, object> _cache;
+
+        private static Dictionary<string, object> Cache
         {
-            if (localSettings != null)
+            get
             {
-                saveSetting("bar_size", 50);
-                saveSetting("monitor", @"\\.\DISPLAY1");
-                saveSetting("LoadOnStartup", true);
-                saveSetting("edge", 1);
-                saveSetting("autohide", false);
+                if (_cache != null) return _cache;
+                _cache = Load();
+                return _cache;
             }
         }
-        
-        public static void saveSetting(string setting, object value)
-        {
 
-            // Save a setting locally on the device
-            localSettings.Values[setting] = value;
+        private static Dictionary<string, object> Load()
+        {
+            try
+            {
+                if (!File.Exists(SettingsPath)) return new Dictionary<string, object>();
+                var json = File.ReadAllText(SettingsPath);
+                if (string.IsNullOrWhiteSpace(json)) return new Dictionary<string, object>();
+                var raw = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)
+                          ?? new Dictionary<string, JsonElement>();
+                var result = new Dictionary<string, object>(raw.Count);
+                foreach (var kv in raw) result[kv.Key] = ConvertElement(kv.Value);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Failed to load settings.json: " + ex.Message);
+                return new Dictionary<string, object>();
+            }
         }
 
-      
+        private static object ConvertElement(JsonElement el) => el.ValueKind switch
+        {
+            JsonValueKind.String => el.GetString(),
+            JsonValueKind.Number => el.TryGetInt32(out int i) ? (object)i : el.GetDouble(),
+            JsonValueKind.True   => true,
+            JsonValueKind.False  => false,
+            JsonValueKind.Null   => null,
+            _                    => null,
+        };
+
+        public static void setDefaultValues()
+        {
+            saveSetting("bar_size", 50);
+            saveSetting("monitor", @"\\.\DISPLAY1");
+            saveSetting("LoadOnStartup", true);
+            saveSetting("edge", 1);
+            saveSetting("autohide", false);
+        }
+
+        public static void saveSetting(string setting, object value)
+        {
+            Cache[setting] = value;
+            Flush();
+        }
 
         public static object loadSettings(string setting)
         {
+            return Cache.TryGetValue(setting, out var v) ? v : null;
+        }
 
-            // load a setting that is local to the device
-            if (localSettings.Values[setting] != null)
+        private static void Flush()
+        {
+            try
             {
-                return localSettings.Values[setting];
+                Directory.CreateDirectory(SettingsDir);
+                File.WriteAllText(SettingsPath,
+                    JsonSerializer.Serialize(Cache, new JsonSerializerOptions { WriteIndented = true }));
             }
-            else
+            catch (Exception ex)
             {
-                return null;
+                Debug.WriteLine("Failed to persist settings.json: " + ex.Message);
             }
+        }
+
+        // True when running inside an MSIX package (has Package identity).
+        // Used to pick StartupTask API vs. HKCU Run key for "load on startup".
+        public static bool IsPackaged()
+        {
+            try { _ = Windows.ApplicationModel.Package.Current; return true; }
+            catch { return false; }
         }
     }
 }

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -98,21 +98,5 @@ namespace AppAppBar3
             try { _ = Windows.ApplicationModel.Package.Current; return true; }
             catch { return false; }
         }
-
-        // Simple file logger for diagnosing sizing/DPI issues. Appends to
-        // %LOCALAPPDATA%\AppAppBar3_debug.log. Failures are swallowed — this is best-effort.
-        private static readonly string DebugLogPath =
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                         "AppAppBar3_debug.log");
-
-        public static void FileLog(string message)
-        {
-            try
-            {
-                File.AppendAllText(DebugLogPath,
-                    DateTime.Now.ToString("HH:mm:ss.fff") + " " + message + Environment.NewLine);
-            }
-            catch { }
-        }
     }
 }

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -19,6 +19,7 @@ namespace AppAppBar3
                 saveSetting("monitor", @"\\.\DISPLAY1");
                 saveSetting("LoadOnStartup", true);
                 saveSetting("edge", 1);
+                saveSetting("autohide", false);
             }
         }
         

--- a/AppAppBar3/Settings.xaml
+++ b/AppAppBar3/Settings.xaml
@@ -33,6 +33,7 @@
             <Button x:Name="restartAppBarButton" Margin="10,10,0,0" Content="Apply" Click="restartAppBarButton_Click" Visibility="Collapsed" IsTabStop="True"/>
         </StackPanel>
         <CheckBox x:Name="loadOnStartupCheckBox" Click="loadOnStartupCheckBox_Click"  Margin="10,10,0,0" Content="Load on Startup" IsTabStop="False"></CheckBox>
+            <CheckBox x:Name="autohideCheckBox" Click="autohideCheckBox_Click" Margin="10,10,0,0" Content="Auto-hide" IsTabStop="False"></CheckBox>
             <Button x:Name="closeSettingsButton" Margin="220,70,0,0" Content="Close" Click="closeSettingsButton_Click"/>
         
 

--- a/AppAppBar3/Settings.xaml
+++ b/AppAppBar3/Settings.xaml
@@ -10,11 +10,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="Settings"
-    Height="400"
+    Height="480"
     Width="300"
     IsShownInSwitchers="False">
 
-    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="400" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
+    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="480" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
         
           
         <TextBlock Margin="10,10,0,0">Startup Edge:</TextBlock>

--- a/AppAppBar3/Settings.xaml.cs
+++ b/AppAppBar3/Settings.xaml.cs
@@ -21,8 +21,7 @@ namespace AppAppBar3
     using static NativeMethods;
     public sealed partial class Settings : WinUIEx.WindowEx
     {
-       
-        public const int ABN_POSCHANGED = 1;
+
         public int appBarCallBack;
         WindowMessageMonitor monitor;
         MainWindow parentWindow;
@@ -55,6 +54,15 @@ namespace AppAppBar3
             cbEdgeSettings.SelectedItem = (ABEdge)loadSettings("edge");
 
             loadOnStartupCheckBox.IsChecked = loadOnStartup("LoadOnStartup");
+
+            var autohideSetting = loadSettings("autohide");
+            autohideCheckBox.IsChecked = autohideSetting is bool b && b;
+        }
+
+        private void autohideCheckBox_Click(object sender, RoutedEventArgs e)
+        {
+            saveSetting("autohide", autohideCheckBox.IsChecked == true);
+            parentWindow.restartAppBar();
         }
         private void OnActivated(object sender, Microsoft.UI.Xaml.WindowActivatedEventArgs args)
         {
@@ -65,22 +73,16 @@ namespace AppAppBar3
 
         private void OnWindowMessageReceived(object sender, WindowMessageEventArgs e)
         {
-            const int WM_DISPLAYCHANGE = 7;
             Debug.WriteLine("AppBar call back " +appBarCallBack.ToString());
             Debug.WriteLine("*************Settings Window Message receieved********** " + e.Message.MessageId.ToString());
 
             if (e.Message.MessageId == appBarCallBack)
             {
-                // Debug.WriteLine("*************Message receieved in callback********** " + e.Message.ToString());
                 switch (e.Message.WParam)
                 {
 
-                    case (int)ABN_POSCHANGED:
+                    case (int)ABNotify.ABN_POSCHANGED:
                          Debug.WriteLine("*************Message callback recieved in Settings Window********** " + e.Message.ToString());
-                        //  monitor.WindowMessageReceived -= OnWindowMessageReceived;
-                        // relocateWindowLocation();
-                        //  monitor.WindowMessageReceived += OnWindowMessageReceived;
-
                         break;
 
                 }
@@ -89,13 +91,7 @@ namespace AppAppBar3
             {
 
                 case WM_DISPLAYCHANGE:
-                    monitor.WindowMessageReceived -= OnWindowMessageReceived;
-                   
                     Debug.WriteLine("Monitor attached ");
-
-
-                    monitor.WindowMessageReceived += OnWindowMessageReceived;
-
                     break;
                // case (int)AppBarMessages.ABM_WINDOWPOSCHANGED:
                     //Debug.WriteLine("window changed position changed notification " + e.Message.ToString());

--- a/AppAppBar3/Settings.xaml.cs
+++ b/AppAppBar3/Settings.xaml.cs
@@ -103,19 +103,40 @@ namespace AppAppBar3
 
         }
 
+        private const string RunKeyPath   = @"Software\Microsoft\Windows\CurrentVersion\Run";
+        private const string RunValueName = "AppAppBar3";
+        private const string StartupTaskId = "AppAppBar3Id";
+
         private bool loadOnStartup(string setting)
         {
-            ApplicationDataContainer localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
-
-            // load a setting that is local to the device
-            if (localSettings.Values[setting] != null)
+            // Packaged build: reflect the actual StartupTask state (respects user's Startup Apps page).
+            // Unpackaged build: reflect presence of the HKCU Run value.
+            if (SettingMethods.IsPackaged())
             {
-                return (bool)(localSettings.Values[setting]);
+                try
+                {
+                    var task = Windows.ApplicationModel.StartupTask.GetAsync(StartupTaskId).GetAwaiter().GetResult();
+                    return task.State == Windows.ApplicationModel.StartupTaskState.Enabled
+                        || task.State == Windows.ApplicationModel.StartupTaskState.EnabledByPolicy;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("StartupTask query failed: " + ex.Message);
+                }
             }
             else
             {
-                return false;
+                try
+                {
+                    using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath);
+                    return key?.GetValue(RunValueName) != null;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("HKCU Run read failed: " + ex.Message);
+                }
             }
+            return loadSettings(setting) as bool? ?? false;
         }
 
 
@@ -157,30 +178,61 @@ namespace AppAppBar3
 
         private async void loadOnStartupCheckBox_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            Windows.ApplicationModel.StartupTask startupTask = await Windows.ApplicationModel.StartupTask.GetAsync("AppAppBar3Id");
-        if((sender as CheckBox).IsChecked == true)
+            bool wantEnabled = (sender as CheckBox).IsChecked == true;
+
+            if (SettingMethods.IsPackaged())
             {
-                switch (startupTask.State)
+                try
                 {
-                    case Windows.ApplicationModel.StartupTaskState.Disabled:
-                        Windows.ApplicationModel.StartupTaskState state = await startupTask.RequestEnableAsync();
-                        saveSetting("LoadOnStartup", true);
-                        break;
-                    case Windows.ApplicationModel.StartupTaskState.DisabledByUser:
-                        Debug.WriteLine("Run at startup Startup disabled by user");
-                        break;
-                    case Windows.ApplicationModel.StartupTaskState.DisabledByPolicy:
-                        Debug.WriteLine("Run at startup Startup disabled by Policy");
-                        break;
-                    case Windows.ApplicationModel.StartupTaskState.EnabledByPolicy:
-                        Debug.WriteLine("Run at startup Startup Enabled by Policy");
-                        break;
-                } 
-             }else
-            {
-                startupTask.Disable();
-                saveSetting("LoadOnStartup", false);
+                    var startupTask = await Windows.ApplicationModel.StartupTask.GetAsync(StartupTaskId);
+                    if (wantEnabled)
+                    {
+                        switch (startupTask.State)
+                        {
+                            case Windows.ApplicationModel.StartupTaskState.Disabled:
+                                await startupTask.RequestEnableAsync();
+                                break;
+                            case Windows.ApplicationModel.StartupTaskState.DisabledByUser:
+                                Debug.WriteLine("Startup disabled by user — enable in Settings > Apps > Startup.");
+                                break;
+                            case Windows.ApplicationModel.StartupTaskState.DisabledByPolicy:
+                                Debug.WriteLine("Startup disabled by policy.");
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        startupTask.Disable();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("StartupTask toggle failed: " + ex.Message);
+                }
             }
+            else
+            {
+                try
+                {
+                    using var key = Registry.CurrentUser.CreateSubKey(RunKeyPath, writable: true);
+                    if (wantEnabled)
+                    {
+                        var exe = Environment.ProcessPath;
+                        if (!string.IsNullOrEmpty(exe))
+                            key.SetValue(RunValueName, "\"" + exe + "\"");
+                    }
+                    else
+                    {
+                        key.DeleteValue(RunValueName, throwOnMissingValue: false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("HKCU Run write failed: " + ex.Message);
+                }
+            }
+
+            saveSetting("LoadOnStartup", wantEnabled);
         }
 
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- Adds a working auto-hide mode for the WinUI 3 system AppBar (sliding show/hide with ABM_SETAUTOHIDEBAREX + DispatcherTimer state machine, ABN_FULLSCREENAPP suppression, monitor/edge-aware).
- Hardens the Win32 AppBar lifecycle: correct ABM_ enum values, WM_ACTIVATE / WM_WINDOWPOSCHANGED forwarded to the shell, TaskbarCreated re-registration, WindowMessageMonitor disposed, fixed WM_DISPLAYCHANGE (0x7E, not WM_SETFOCUS), per-monitor DPI on autohide slivers.
- Packaging: works as MSIX and as unpackaged (runtime-dep or self-contained). Settings persisted in `%LOCALAPPDATA%\AppAppBar3\settings.json`; load-on-startup branches between StartupTask (packaged) and HKCU Run key (unpackaged).
- Toolchain: retargeted to .NET 8, WindowsAppSDK 1.8.260317003, portable win-x64 RIDs, global.json pins 8.0.x, dropped legacy package refs and the COM type-lib reference that blocked `dotnet publish`.
- CI: GitHub Actions workflow builds all three variants on push and uploads signed MSIX + both unpackaged zips as artifacts.

## Test plan
- [ ] MSIX install path: download `AppAppBar3-MSIX-x64` artifact, import `ci-cert.cer` into LocalMachine\TrustedPeople, run `Install.ps1`; app launches and autohide toggle in Settings behaves.
- [ ] Unpackaged runtime-dep: Windows App Runtime 1.8 installed, run `AppAppBar3.exe` from extracted folder.
- [ ] Unpackaged self-contained: extract and run — no install prereq.
- [ ] Docked mode: bar reserves work area on all edges, multi-monitor.
- [ ] Autohide mode: bar slides off with a 2 px trigger strip, slides back smoothly; fullscreen video suppresses it.
- [ ] Edge / monitor changes via Settings re-register the bar without orphaning the prior registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)