### PR TITLE
Add user-selectable theme (Default/Light/Dark) with live system follow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [Experimental, master]
+    branches: [Experimental, Experimental-2, master]
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -119,6 +119,7 @@ namespace AppAppBar3
         {
 
             this.InitializeComponent();
+            ThemeHelper.Register(this);
             // Override the XAML MinWidth/MinHeight floor — WinUIEx.WindowEx's
             // WM_WINDOWPOSCHANGING interceptor was clamping our Left/Right bar up to
             // ~132 DIPs even when we asked for 50, because MinWidth=25 in XAML wasn't

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -445,7 +445,11 @@ namespace AppAppBar3
             DWMWA_CLOAK,
             DWMWA_CLOAKED,
             DWMWA_FREEZE_REPRESENTATION,
-            DWMWA_LAST
+            DWMWA_LAST,
+            // Win32 attribute id 20: tints the non-client caption (and its buttons)
+            // for dark mode. Out of order in the source enum because the Win10
+            // header defined it long after DWMWA_LAST was named.
+            DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
         }
         //remove window decorations by removing border, caption, titlebar etc
         //remove corner radius by removing border and caption, remove title bar

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -64,6 +64,7 @@ namespace AppAppBar3
             saveSetting("LoadOnStartup", true);
             saveSetting("edge", 1);
             saveSetting("autohide", false);
+            saveSetting("theme", "Default");
         }
 
         public static void saveSetting(string setting, object value)

--- a/AppAppBar3/Settings.xaml
+++ b/AppAppBar3/Settings.xaml
@@ -34,6 +34,8 @@
         </StackPanel>
         <CheckBox x:Name="loadOnStartupCheckBox" Click="loadOnStartupCheckBox_Click"  Margin="10,10,0,0" Content="Load on Startup" IsTabStop="False"></CheckBox>
             <CheckBox x:Name="autohideCheckBox" Click="autohideCheckBox_Click" Margin="10,10,0,0" Content="Auto-hide" IsTabStop="False"></CheckBox>
+            <TextBlock Margin="10,10,0,0">Theme:</TextBlock>
+            <ComboBox x:Name="cbThemeSettings" Margin="10,10,0,0" Width="200" MinWidth="200" SelectionChanged="cbThemeSettings_SelectionChanged"/>
             <Button x:Name="closeSettingsButton" Margin="220,70,0,0" Content="Close" Click="closeSettingsButton_Click"/>
         
 

--- a/AppAppBar3/Settings.xaml.cs
+++ b/AppAppBar3/Settings.xaml.cs
@@ -33,6 +33,7 @@ namespace AppAppBar3
             appBarCallBack = appBarCall;
             parentWindow = Parent;
             this.InitializeComponent();
+            ThemeHelper.Register(this);
             this.Activated += OnActivated;
             monitor = new WindowMessageMonitor(this);
             monitor.WindowMessageReceived += OnWindowMessageReceived;
@@ -57,6 +58,19 @@ namespace AppAppBar3
 
             var autohideSetting = loadSettings("autohide");
             autohideCheckBox.IsChecked = autohideSetting is bool b && b;
+
+            // Populate theme picker after the constructor sets the saved selection,
+            // so cbThemeSettings_SelectionChanged doesn't fire during initial load.
+            cbThemeSettings.SelectionChanged -= cbThemeSettings_SelectionChanged;
+            cbThemeSettings.ItemsSource = Enum.GetValues(typeof(ElementTheme));
+            cbThemeSettings.SelectedItem = ThemeHelper.LoadSavedTheme();
+            cbThemeSettings.SelectionChanged += cbThemeSettings_SelectionChanged;
+        }
+
+        private void cbThemeSettings_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (cbThemeSettings.SelectedItem is ElementTheme t)
+                ThemeHelper.SaveAndApply(t);
         }
 
         private void autohideCheckBox_Click(object sender, RoutedEventArgs e)

--- a/AppAppBar3/ThemeHelper.cs
+++ b/AppAppBar3/ThemeHelper.cs
@@ -1,0 +1,122 @@
+using Microsoft.UI.Xaml;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace AppAppBar3
+{
+    // Applies the user's saved theme preference to every WinUI window in the
+    // app, and re-applies on Windows theme flips when the user has chosen
+    // "Default" (follow Windows).
+    //
+    // We resolve "Default" to an explicit Light/Dark by reading
+    // HKCU\...\Personalize\AppsUseLightTheme rather than leaving
+    // RequestedTheme = Default — WinUI 3 desktop windows don't reliably
+    // repaint when the system theme flips at runtime.
+    public static class ThemeHelper
+    {
+        private const string SettingKey = "theme";
+
+        private static readonly List<Window> _windows = new();
+        private static bool _systemEventsHooked;
+
+        public static ElementTheme LoadSavedTheme()
+        {
+            var raw = SettingMethods.loadSettings(SettingKey) as string;
+            return Enum.TryParse<ElementTheme>(raw, out var t) ? t : ElementTheme.Default;
+        }
+
+        public static void SaveAndApply(ElementTheme theme)
+        {
+            SettingMethods.saveSetting(SettingKey, theme.ToString());
+            ApplyAll();
+        }
+
+        public static void Register(Window window)
+        {
+            if (window == null || _windows.Contains(window)) return;
+            _windows.Add(window);
+            window.Closed += (s, e) => _windows.Remove(window);
+            Apply(window, LoadSavedTheme());
+            EnsureSystemEventsHooked();
+        }
+
+        public static void ApplyAll()
+        {
+            var saved = LoadSavedTheme();
+            foreach (var w in _windows.ToArray()) Apply(w, saved);
+        }
+
+        private static void Apply(Window window, ElementTheme saved)
+        {
+            var resolved = saved == ElementTheme.Default ? ResolveSystemTheme() : saved;
+
+            if (window?.Content is FrameworkElement fe)
+            {
+                // Setting to the resolved Light/Dark (rather than Default) ensures the
+                // ThemeResource brushes flip immediately on a system theme change.
+                fe.RequestedTheme = resolved;
+            }
+
+            ApplyImmersiveDarkMode(window, resolved);
+        }
+
+        private static ElementTheme ResolveSystemTheme()
+        {
+            try
+            {
+                using var key = Registry.CurrentUser.OpenSubKey(
+                    @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
+                if (key?.GetValue("AppsUseLightTheme") is int i)
+                    return i == 0 ? ElementTheme.Dark : ElementTheme.Light;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("ResolveSystemTheme failed: " + ex.Message);
+            }
+            return ElementTheme.Light;
+        }
+
+        private static void ApplyImmersiveDarkMode(Window window, ElementTheme resolved)
+        {
+            if (window == null) return;
+            try
+            {
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+                int useDark = resolved == ElementTheme.Dark ? 1 : 0;
+                NativeMethods.DwmSetWindowAttribute(
+                    hwnd,
+                    NativeMethods.DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE,
+                    ref useDark,
+                    sizeof(int));
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("ApplyImmersiveDarkMode failed: " + ex.Message);
+            }
+        }
+
+        private static void EnsureSystemEventsHooked()
+        {
+            if (_systemEventsHooked) return;
+            _systemEventsHooked = true;
+            SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+        }
+
+        private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
+        {
+            if (e.Category != UserPreferenceCategory.General) return;
+            // Only react when the user is following Windows; explicit Light/Dark wins.
+            if (LoadSavedTheme() != ElementTheme.Default) return;
+
+            // Fires on a non-UI thread — marshal each apply to its window's dispatcher.
+            foreach (var w in _windows.ToArray())
+            {
+                var dq = w.DispatcherQueue;
+                if (dq == null) continue;
+                dq.TryEnqueue(() => Apply(w, ElementTheme.Default));
+            }
+        }
+    }
+}

--- a/AppAppBar3/WebWindow.xaml.cs
+++ b/AppAppBar3/WebWindow.xaml.cs
@@ -15,6 +15,7 @@ namespace AppAppBar3
         {
             
             this.InitializeComponent();
+            ThemeHelper.Register(this);
             InitializeWebView();
             IntPtr hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             WindowId windowId = Win32Interop.GetWindowIdFromWindow(hwnd);

--- a/AppAppBar3/WindowDetect.xaml.cs
+++ b/AppAppBar3/WindowDetect.xaml.cs
@@ -30,6 +30,7 @@ namespace AppAppBar3
         public WindowDetect(string Text)
         {
             this.InitializeComponent();
+            ThemeHelper.Register(this);
             SetTimer();
             DisplayText.Text = Text;
             IntPtr hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For running the **unpackaged** builds (not MSIX) the target machine also needs t
 - Handles per-monitor DPI scaling
 - Does not show in switcher
 - Excluded from aero peek
-- Follows current Windows desktop theme
+- Theme picker in Settings (Default / Light / Dark) — "Default" follows the current Windows theme and re-applies live when the system theme flips
 - Handles Drag and drop shortcut with deletion, autosaving and auto restore on startup
 - Option to run at login (autostart).
 - Settings persisted to `%LOCALAPPDATA%\AppAppBar3\settings.json` so packaged and unpackaged builds share the same storage.
@@ -37,9 +37,13 @@ For running the **unpackaged** builds (not MSIX) the target machine also needs t
 - Build into Library
 - code refractoring
 - Bug fixes
-- allow for custom theme (currenlty only supports current desktop theme)
 
 ## Notes
+04/29/26  Added a user-selectable theme on the **Experimental-2** branch:
+- New **Theme** picker in Settings (Default / Light / Dark). "Default" follows the current Windows theme.
+- A new `ThemeHelper` resolves "Default" against `HKCU\...\Personalize\AppsUseLightTheme` and hooks `SystemEvents.UserPreferenceChanged` so all open windows repaint immediately when the system theme flips — WinUI 3 desktop windows don't reliably do this on their own with `RequestedTheme = Default`.
+- Non-client caption (where still visible) tints via `DwmSetWindowAttribute(DWMWA_USE_IMMERSIVE_DARK_MODE)` to match the resolved theme.
+
 04/20/26  Merged the **Experimental** branch into master. Summary of what changed:
 - Added a working **auto-hide** AppBar mode (ABM_SETAUTOHIDEBAREX + a DispatcherTimer state machine that slides the bar in/out with a ~200 ms ease-out, and suppresses itself over fullscreen apps via ABN_FULLSCREENAPP).
 - Hardened the Win32 AppBar contract: corrected ABM_ message IDs, forward WM_ACTIVATE / WM_WINDOWPOSCHANGED to the shell, re-register on TaskbarCreated (explorer restart), dispose WindowMessageMonitor, fix WM_DISPLAYCHANGE (was accidentally WM_SETFOCUS), per-monitor DPI on the autohide trigger sliver.


### PR DESCRIPTION
Targets `Experimental` (was originally opened against `master` by mistake).

## Summary
- Adds a **Theme** picker to the Settings window (Default / Light / Dark). "Default" follows the current Windows theme.
- New `ThemeHelper` resolves "Default" against `HKCU\...\Personalize\AppsUseLightTheme` and hooks `SystemEvents.UserPreferenceChanged` once, so all open windows repaint immediately when the system theme flips at runtime — WinUI 3 desktop windows don't reliably do this on their own with `RequestedTheme = Default`.
- Tints any visible non-client caption via `DwmSetWindowAttribute(DWMWA_USE_IMMERSIVE_DARK_MODE)` to match the resolved theme.
- README updated: replaces the "Follows current Windows desktop theme" capability with the picker, drops the corresponding TODO, and adds an 04/29/26 Notes entry.
- CI: the existing `build.yml` (MSIX + unpackaged runtime-dep + unpackaged self-contained) now also triggers on pushes to `Experimental-2`.

## Notes on merging into Experimental
`Experimental` has 14 commits not on `master` (recent drag-resize / `ABM_SETPOS` work that was reverted). This PR was branched from `master`, so the merge into `Experimental` will be a true merge, not a fast-forward. No edits in this PR touch the autohide / `SetWindowPos` paths that the `Experimental` work touched, so conflicts should be limited to README "Notes" / "To do" sections if anything.

## Test plan
- [ ] Build all three flavors via the GitHub Actions workflow (MSIX, unpackaged runtime-dep, unpackaged self-contained) — covered by the matrix on push.
- [ ] Open Settings; switch Theme between Default / Light / Dark and confirm MainWindow + Settings + Web window + Identify-Monitor overlay all repaint.
- [ ] With Theme = Default, change Windows Settings > Personalization > Colors mode (Light ↔ Dark) and confirm windows flip without restart.
- [ ] With Theme = Light, change Windows to Dark and confirm app stays Light (explicit pin wins).
- [ ] Verify `%LOCALAPPDATA%\AppAppBar3\settings.json` contains `"theme"` after a selection change.
- [ ] Sanity-check that AppBar registration, autohide, and the WinUIEx MinWidth workaround are unaffected — Theme work is XAML-tree-only and doesn't touch the `SetWindowPos` paths.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH