### PR TITLE
Fix Theme combobox showing IReference&lt;T&gt; instead of enum names

### DIFF
--- a/AppAppBar3/Settings.xaml.cs
+++ b/AppAppBar3/Settings.xaml.cs
@@ -61,16 +61,22 @@ namespace AppAppBar3
 
             // Populate theme picker after the constructor sets the saved selection,
             // so cbThemeSettings_SelectionChanged doesn't fire during initial load.
+            // Use strings rather than ElementTheme values: the WinRT projection wraps
+            // boxed enum values in IReference<T>, and ComboBox falls back to the
+            // wrapper's ToString() which shows "Windows.Foundation.IReference`1<...>".
             cbThemeSettings.SelectionChanged -= cbThemeSettings_SelectionChanged;
-            cbThemeSettings.ItemsSource = Enum.GetValues(typeof(ElementTheme));
-            cbThemeSettings.SelectedItem = ThemeHelper.LoadSavedTheme();
+            cbThemeSettings.ItemsSource = Enum.GetNames(typeof(ElementTheme));
+            cbThemeSettings.SelectedItem = ThemeHelper.LoadSavedTheme().ToString();
             cbThemeSettings.SelectionChanged += cbThemeSettings_SelectionChanged;
         }
 
         private void cbThemeSettings_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (cbThemeSettings.SelectedItem is ElementTheme t)
+            if (cbThemeSettings.SelectedItem is string s
+                && Enum.TryParse<ElementTheme>(s, out var t))
+            {
                 ThemeHelper.SaveAndApply(t);
+            }
         }
 
         private void autohideCheckBox_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Follow-up to #12. The Theme dropdown in Settings was rendering each row as `Windows.Foundation.IReference\`1<Microsoft.UI.Xaml.ElementTheme>` because the WinRT projection wraps boxed `ElementTheme` values in `IReference<T>`, and ComboBox's `DisplayMemberPath` fallback ends up calling `ToString()` on the wrapper.

## Change
Bind `cbThemeSettings.ItemsSource` to `Enum.GetNames(typeof(ElementTheme))` (plain strings) and map the selected string back to `ElementTheme` via `Enum.TryParse` in the SelectionChanged handler. Initial selection is set from `ThemeHelper.LoadSavedTheme().ToString()`.

Single commit, single file (`AppAppBar3/Settings.xaml.cs`), ~9 lines changed. No behavioral change beyond what the user sees in the dropdown.

## Test plan
- [ ] CI matrix green on push.
- [ ] Open Settings — Theme dropdown shows **Default**, **Light**, **Dark**.
- [ ] Selecting any of the three saves to `settings.json` and applies live as before.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_