### PR TITLE
Drop redundant Close buttons; shrink Settings window

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -34,7 +34,6 @@
                </ComboBox>
                 <Button Content="Close" Margin="0,0,0,0" Click="CloseButton_Click" Width="{Binding ItemWidth, ElementName=VariableGrid}"/>
             <CommandBar HorizontalAlignment="Right" x:Name="theCommandBar" MinWidth="{Binding ItemWidth, ElementName=VariableGrid}">
-                <AppBarButton Icon="Clear" Click="CloseButton_Click" Label="Close"/>
                 <AppBarButton Icon="DockRight" Label="Right"/>
                 <AppBarButton Icon="DockBottom" Label="Bottom"/>
                 <AppBarButton Icon="DockLeft" Label="Left"/>

--- a/AppAppBar3/Settings.xaml
+++ b/AppAppBar3/Settings.xaml
@@ -10,11 +10,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="Settings"
-    Height="560"
+    Height="450"
     Width="300"
     IsShownInSwitchers="False">
 
-    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="560" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
+    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="450" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
         
           
         <TextBlock Margin="10,10,0,0">Startup Edge:</TextBlock>
@@ -36,7 +36,6 @@
             <CheckBox x:Name="autohideCheckBox" Click="autohideCheckBox_Click" Margin="10,10,0,0" Content="Auto-hide" IsTabStop="False"></CheckBox>
             <TextBlock Margin="10,10,0,0">Theme:</TextBlock>
             <ComboBox x:Name="cbThemeSettings" Margin="10,10,0,0" Width="200" MinWidth="200" SelectionChanged="cbThemeSettings_SelectionChanged"/>
-            <Button x:Name="closeSettingsButton" Margin="220,70,0,0" Content="Close" Click="closeSettingsButton_Click"/>
         
 
 

--- a/AppAppBar3/Settings.xaml.cs
+++ b/AppAppBar3/Settings.xaml.cs
@@ -200,13 +200,7 @@ namespace AppAppBar3
             saveSetting("edge", (int)cbEdgeSettings.SelectedItem);
         }
 
-        private void closeSettingsButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
-        {
-            parentWindow.closeSettingsWindow();
-            //this.Close();
-        }
 
-       
 
         private async void loadOnStartupCheckBox_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {


### PR DESCRIPTION
Follow-up to #14.

## Change
- **MainWindow**: drop the `AppBarButton Icon="Clear" Label="Close"` from the right-hand `CommandBar`. It duplicated the standalone `<Button Content="Close">` already in the toolbar; the standalone one stays as the sole UI affordance to exit the app.
- **Settings window**: remove `closeSettingsButton` and its orphaned `closeSettingsButton_Click` handler. Settings light-dismisses on focus loss now (#14's predecessor on this branch), so an explicit Close is redundant.
- **Settings height**: 560 → 450 px to reclaim the ~100 px the Close button + its 70-px top margin used.

Three files, +2 / −10.

## Test plan
- [ ] CI matrix green on push.
- [ ] AppBar's CommandBar shows DockRight / DockBottom / DockLeft / Identify Monitor / Settings — no Close.
- [ ] Standalone Close button in the AppBar toolbar still exits the app.
- [ ] Settings window opens at 450 px tall; Theme combobox is the last visible row, no truncation.
- [ ] Clicking outside Settings still light-dismisses it.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_