### PR TITLE
Borderless AppBar, friendly monitor names, right-click menu

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -18,7 +18,27 @@
 
 
     <StackPanel x:Name="stPanel" Background="{ThemeResource SystemChromeMediumLowColor}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Horizontal" AllowDrop="True" DragOver="Grid_DragOver" DragLeave="DragLeave" Drop="Grid_Drop" CanDrag="True">
-        
+        <StackPanel.ContextFlyout>
+            <MenuFlyout>
+                <MenuFlyoutItem Text="Settings" Click="Settings_Click">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="Setting"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Identify Monitor" Click="DetectWindow_click">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE7F4;"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Close AppBar" Click="CloseButton_Click">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="Cancel"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+            </MenuFlyout>
+        </StackPanel.ContextFlyout>
+
             <VariableSizedWrapGrid Orientation="Horizontal"  x:Name="VariableGrid" AllowDrop="False" DragOver="Grid_DragOver" Drop="Grid_Drop" CanDrag="True" MaximumRowsOrColumns="120" ItemHeight="50" ItemWidth="100" HorizontalAlignment="Left" HorizontalChildrenAlignment="Left" >
 
             <ToggleButton  x:Name="webButton" Content="Web" Click="openWebWindow" Width="{Binding ItemWidth, ElementName=VariableGrid}">
@@ -27,12 +47,11 @@
 
 
             <ComboBox x:Name="edgeMonitor"  Margin="5,9,5,0"  SelectedItem="{Binding Edge, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"  SelectionChanged="edgeComboBox_SelectionChanged"  PlaceholderText="Top" Width="{Binding ItemWidth, ElementName=layoutFlexGrid}" >
-                    
+
                 </ComboBox>
             <ComboBox x:Name="cbMonitor"  Margin="0,9,5,0" ItemsSource="{Binding ListOfMonitors, Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" SelectionChanged="DisplayComboBox_SelectionChanged"  PlaceholderText="Pick Screen" Width="{Binding ItemWidth, ElementName=layoutFlexGrid}" MinWidth="200">
 
                </ComboBox>
-                <Button Content="Close" Margin="0,0,0,0" Click="CloseButton_Click" Width="{Binding ItemWidth, ElementName=VariableGrid}"/>
             <CommandBar HorizontalAlignment="Right" x:Name="theCommandBar" MinWidth="{Binding ItemWidth, ElementName=VariableGrid}">
                 <AppBarButton Icon="DockRight" Label="Right"/>
                 <AppBarButton Icon="DockBottom" Label="Bottom"/>

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -165,6 +165,7 @@ namespace AppAppBar3
                 {
                     SettingMethods.setDefaultValues();
                 }
+                MigrateLegacyMonitorSetting();
                 edgeMonitor.SelectedItem = (ABEdge)loadSettings("edge");
                 cbMonitor.SelectedItem = (string)loadSettings("monitor");
                
@@ -173,6 +174,15 @@ namespace AppAppBar3
                 IntPtr hWnd = WindowNative.GetWindowHandle(this);
                 WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
                 appWindow = AppWindow.GetFromWindowId(windowId);
+
+                // The OverlappedPresenter still draws a thin window border even
+                // after we strip WS_CAPTION/WS_THICKFRAME via SetWindowLong; this
+                // is the WinAppSDK-native way to suppress it.
+                if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter op)
+                {
+                    op.HasBorder = false;
+                    op.HasTitleBar = false;
+                }
 
                 //remove from aero peek
                     int value = 0x01;
@@ -208,6 +218,20 @@ namespace AppAppBar3
         }
 
        
+
+        // settings.json from older builds stored the Win32 device path
+        // ("\\.\DISPLAY1"). Convert to the new "Display N" form once so the
+        // saved monitor matches an item in cbMonitor's ItemsSource.
+        private static void MigrateLegacyMonitorSetting()
+        {
+            if (loadSettings("monitor") is string saved
+                && saved.StartsWith(@"\\.\", StringComparison.Ordinal))
+            {
+                var migrated = MonitorHelper.FormatDisplayName(saved);
+                if (!string.Equals(migrated, saved, StringComparison.Ordinal))
+                    saveSetting("monitor", migrated);
+            }
+        }
 
         private void RegisterAppBar(ABEdge edge, string selectedMonitor)
         {

--- a/AppAppBar3/MonitorHelper.cs
+++ b/AppAppBar3/MonitorHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 
 namespace AppAppBar3
@@ -12,12 +13,22 @@ namespace AppAppBar3
     {
         public class Monitor
         {
-           // public string FriendlyMonitorName;
-            //public SizeAndPosition SizeAndPosition;
+            // Friendly label shown in UI (e.g. "Display 1"). Also used as the stable
+            // identifier in settings.json — internal code matches on this string,
+            // so MonitorName must round-trip through SettingMethods unchanged.
             public string MonitorName;
             public double scale;
             public RECT WorkRect;
             public RECT MonitorRect;
+        }
+
+        // Win32 returns the device path (e.g. "\\.\DISPLAY1"). Format it as
+        // "Display N" for the UI; the digit suffix is stable across boots.
+        public static string FormatDisplayName(string szDevice)
+        {
+            if (string.IsNullOrEmpty(szDevice)) return szDevice;
+            var m = Regex.Match(szDevice, @"DISPLAY(\d+)", RegexOptions.IgnoreCase);
+            return m.Success ? "Display " + m.Groups[1].Value : szDevice;
         }
 
         public static List<Monitor> GetMonitorsInfo()
@@ -42,7 +53,7 @@ namespace AppAppBar3
 
                     monitors.Add(new Monitor
                     {
-                        MonitorName = mi.szDevice,
+                        MonitorName = FormatDisplayName(mi.szDevice),
                         scale = monitorScale,
                         WorkRect = mi.rcWork,
                         MonitorRect = mi.rcMonitor,

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -60,7 +60,7 @@ namespace AppAppBar3
         public static void setDefaultValues()
         {
             saveSetting("bar_size", 50);
-            saveSetting("monitor", @"\\.\DISPLAY1");
+            saveSetting("monitor", "Display 1");
             saveSetting("LoadOnStartup", true);
             saveSetting("edge", 1);
             saveSetting("autohide", false);


### PR DESCRIPTION
Follow-up to #15. Four UX changes for the AppBar:

## Changes

1. **Borderless AppBar.** Sets `OverlappedPresenter.HasBorder = false` (and `HasTitleBar = false` belt-and-suspenders) on MainWindow's `AppWindow`. WinAppSDK's presenter draws a 1-px window frame even after `WS_CAPTION` / `WS_THICKFRAME` are stripped via `SetWindowLong`; this is the native fix.

2. **Friendly monitor labels.** `MonitorHelper.Monitor.MonitorName` is now `"Display N"` (extracted from the Win32 `\\.\DISPLAYn` device path) instead of the raw path. New `MonitorHelper.FormatDisplayName(string)` does the conversion. The friendly label doubles as the stable id stored in `settings.json` — internal code (`ABSetPos`, `DockToAppBar`, the `DetectWindow_click` regex) all match on this string.
   - Default `monitor` in `setDefaultValues()` changes from `"\\.\DISPLAY1"` → `"Display 1"`.
   - `MainWindow.OnActivated` runs a one-shot **migration** that rewrites any legacy `\\.\…`-prefixed `monitor` value via `FormatDisplayName` so existing users aren't stranded.

3. **Right-click context menu.** `stPanel.ContextFlyout` opens a `MenuFlyout` with Settings, Identify Monitor, and Close AppBar. ComboBox dropdowns and per-shortcut MenuFlyouts are unaffected.

4. **Close moved into the right-click menu.** The standalone `<Button Content="Close">` in the toolbar is gone; "Close AppBar" in the new ContextFlyout wires to the existing `CloseButton_Click`.

Four files, +61 / −7.

## Test plan
- [ ] CI matrix green on push.
- [ ] AppBar shows no visible window border in any edge / theme combination.
- [ ] Monitor combobox lists "Display 1", "Display 2", … (no `\\.\…`).
- [ ] On a machine with an existing `settings.json` containing `"monitor": "\\\\.\\DISPLAY1"`, the migration converts it on first run and the bar still docks to the same monitor.
- [ ] Right-click anywhere on the AppBar surface opens the new context menu (Settings / Identify Monitor / Close AppBar). Items work.
- [ ] No standalone Close button in the toolbar; "Close AppBar" in the menu exits the app (UnregisterAppBar then this.Close()).
- [ ] CommandBar still has DockRight / DockBottom / DockLeft / Identify Monitor / Settings.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_