### PR TITLE
Fix borderless AppBar build: use SetBorderAndTitleBar

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -176,12 +176,12 @@ namespace AppAppBar3
                 appWindow = AppWindow.GetFromWindowId(windowId);
 
                 // The OverlappedPresenter still draws a thin window border even
-                // after we strip WS_CAPTION/WS_THICKFRAME via SetWindowLong; this
-                // is the WinAppSDK-native way to suppress it.
+                // after we strip WS_CAPTION/WS_THICKFRAME via SetWindowLong;
+                // SetBorderAndTitleBar is the WinAppSDK-native way to suppress
+                // it (HasBorder/HasTitleBar themselves are read-only in 1.x).
                 if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter op)
                 {
-                    op.HasBorder = false;
-                    op.HasTitleBar = false;
+                    op.SetBorderAndTitleBar(false, false);
                 }
 
                 //remove from aero peek


### PR DESCRIPTION
Build fix for #16. The borderless-AppBar code in #16 assigned `OverlappedPresenter.HasBorder` and `HasTitleBar` directly, which fails to compile under WinAppSDK 1.x — both properties are getters only:

```
error CS0200: Property or indexer 'OverlappedPresenter.HasBorder' cannot be assigned to -- it is read only
```

Switch to `OverlappedPresenter.SetBorderAndTitleBar(hasBorder, hasTitleBar)`, the documented setter for both at once.

One file, +4 / −4.

## Test plan
- [ ] CI matrix green (the previous push failed compile).
- [ ] AppBar still renders without a visible window border.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_