### PR TITLE
Revert OverlappedPresenter.SetBorderAndTitleBar — blanks the AppBar

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -175,15 +175,6 @@ namespace AppAppBar3
                 WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
                 appWindow = AppWindow.GetFromWindowId(windowId);
 
-                // The OverlappedPresenter still draws a thin window border even
-                // after we strip WS_CAPTION/WS_THICKFRAME via SetWindowLong;
-                // SetBorderAndTitleBar is the WinAppSDK-native way to suppress
-                // it (HasBorder/HasTitleBar themselves are read-only in 1.x).
-                if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter op)
-                {
-                    op.SetBorderAndTitleBar(false, false);
-                }
-
                 //remove from aero peek
                     int value = 0x01;
                     int hr = DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_EXCLUDED_FROM_PEEK, ref value, Marshal.SizeOf(typeof(int)));


### PR DESCRIPTION
Revert of the `OverlappedPresenter.SetBorderAndTitleBar(false, false)` call introduced in #16 / #17.

## Why
With the call in place the AppBar renders blank — no shortcut buttons, no CommandBar, no right-click context menu. Setting `(false, false)` puts the presenter in a no-chrome state that interacts badly with the AppBar's `WS_CAPTION | WS_THICKFRAME` strip in `ApplyDocked` and the `ABM_NEW` registration that follows in `OnActivated`. Net effect: XAML content fails to surface in the client area.

## What's left
`IsTitleBarVisible="False"` in MainWindow.xaml plus the existing `WS_CAPTION | WS_THICKFRAME` strip in `ApplyDocked` / `ApplyAutohide` remain. The borderless-AppBar request from #16 is not yet addressed — alternative paths to try (DWM frame extension with zero margins, a XAML `Border` wrapper) need a screenshot of the actual artifact to pick the right one.

One file, −9 lines.

## Test plan
- [ ] CI matrix green.
- [ ] AppBar shows shortcut buttons, edge / monitor combos, and CommandBar items as before.
- [ ] Right-click context menu still opens (Settings / Identify Monitor / Close AppBar from #16 are unaffected).

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_