### PR TITLE
Dock options to context menu; drop CommandBar / monitor combo; try Win11 borderless

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -20,14 +20,35 @@
     <StackPanel x:Name="stPanel" Background="{ThemeResource SystemChromeMediumLowColor}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Horizontal" AllowDrop="True" DragOver="Grid_DragOver" DragLeave="DragLeave" Drop="Grid_Drop" CanDrag="True">
         <StackPanel.ContextFlyout>
             <MenuFlyout>
-                <MenuFlyoutItem Text="Settings" Click="Settings_Click">
+                <MenuFlyoutItem Text="Dock Top" Click="DockTop_Click">
                     <MenuFlyoutItem.Icon>
-                        <SymbolIcon Symbol="Setting"/>
+                        <SymbolIcon Symbol="Up"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Dock Right" Click="DockRight_Click">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="DockRight"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Dock Bottom" Click="DockBottom_Click">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="DockBottom"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Dock Left" Click="DockLeft_Click">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="DockLeft"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Identify Monitor" Click="DetectWindow_click">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE7F4;"/>
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
+                <MenuFlyoutItem Text="Settings" Click="Settings_Click">
+                    <MenuFlyoutItem.Icon>
+                        <SymbolIcon Symbol="Setting"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator/>
@@ -49,22 +70,6 @@
             <ComboBox x:Name="edgeMonitor"  Margin="5,9,5,0"  SelectedItem="{Binding Edge, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"  SelectionChanged="edgeComboBox_SelectionChanged"  PlaceholderText="Top" Width="{Binding ItemWidth, ElementName=layoutFlexGrid}" >
 
                 </ComboBox>
-            <ComboBox x:Name="cbMonitor"  Margin="0,9,5,0" ItemsSource="{Binding ListOfMonitors, Mode=OneWay,UpdateSourceTrigger=PropertyChanged}" SelectionChanged="DisplayComboBox_SelectionChanged"  PlaceholderText="Pick Screen" Width="{Binding ItemWidth, ElementName=layoutFlexGrid}" MinWidth="200">
-
-               </ComboBox>
-            <CommandBar HorizontalAlignment="Right" x:Name="theCommandBar" MinWidth="{Binding ItemWidth, ElementName=VariableGrid}">
-                <AppBarButton Icon="DockRight" Label="Right"/>
-                <AppBarButton Icon="DockBottom" Label="Bottom"/>
-                <AppBarButton Icon="DockLeft" Label="Left"/>
-                <AppBarButton  Label="Identify Monitor" Click="DetectWindow_click">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE7F4;"/>
-                    </AppBarButton.Icon>
-                </AppBarButton>
-
-                <AppBarButton Icon="Setting" Label="Settings" Click="Settings_Click"/>
-
-            </CommandBar>
         </VariableSizedWrapGrid>
             
         </StackPanel>

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -130,7 +130,6 @@ namespace AppAppBar3
             this.AppWindow.IsShownInSwitchers = false;
             monitorInfo = GetMonitorsInfo();
             MonitorList = new ObservableCollection<Monitor>(GetMonitorsInfo());
-            cbMonitor.DataContext = this;
             edgeMonitor.DataContext = this;
             monitor = new WindowMessageMonitor(this);
             monitor.WindowMessageReceived += OnWindowMessageReceived;
@@ -151,7 +150,6 @@ namespace AppAppBar3
         private void OnActivated(object sender, Microsoft.UI.Xaml.WindowActivatedEventArgs args)
         {
 
-            cbMonitor.SelectionChanged -= DisplayComboBox_SelectionChanged;
             edgeMonitor.SelectionChanged -= edgeComboBox_SelectionChanged;
             // selectedItemsText = @"\\.\DISPLAY1";
 
@@ -167,7 +165,6 @@ namespace AppAppBar3
                 }
                 MigrateLegacyMonitorSetting();
                 edgeMonitor.SelectedItem = (ABEdge)loadSettings("edge");
-                cbMonitor.SelectedItem = (string)loadSettings("monitor");
                
                 
                 Debug.WriteLine("Window activated edge from settings " + (ABEdge)loadSettings("edge"));
@@ -178,6 +175,13 @@ namespace AppAppBar3
                 //remove from aero peek
                     int value = 0x01;
                     int hr = DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_EXCLUDED_FROM_PEEK, ref value, Marshal.SizeOf(typeof(int)));
+
+                    // Suppress the residual 1-px window frame that Win11 paints even
+                    // after WS_CAPTION/WS_THICKFRAME are stripped. DWMWA_BORDER_COLOR
+                    // accepts DWMWA_COLOR_NONE to disable the border outright.
+                    // Ignored on Win10 — call is a safe no-op.
+                    int noBorder = unchecked((int)DWMWA_COLOR_NONE);
+                    DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_BORDER_COLOR, ref noBorder, Marshal.SizeOf(typeof(int)));
 
                 // Ensure we only register the app bar once
                 if (args.WindowActivationState != WindowActivationState.Deactivated)
@@ -200,7 +204,6 @@ namespace AppAppBar3
 
                 }
                 edgeMonitor.SelectionChanged += edgeComboBox_SelectionChanged;
-                cbMonitor.SelectionChanged += DisplayComboBox_SelectionChanged;
                 loadShortCuts();
 
                 
@@ -212,7 +215,7 @@ namespace AppAppBar3
 
         // settings.json from older builds stored the Win32 device path
         // ("\\.\DISPLAY1"). Convert to the new "Display N" form once so the
-        // saved monitor matches an item in cbMonitor's ItemsSource.
+        // saved monitor matches a MonitorList entry.
         private static void MigrateLegacyMonitorSetting()
         {
             if (loadSettings("monitor") is string saved
@@ -639,11 +642,7 @@ namespace AppAppBar3
                     break;
 
                 case WM_DISPLAYCHANGE:
-                    var selectedMon = cbMonitor.SelectedItem as string;
-                    cbMonitor.SelectionChanged -= DisplayComboBox_SelectionChanged;
                     MonitorList = new ObservableCollection<Monitor>(GetMonitorsInfo());
-                    cbMonitor.SelectedItem = selectedMon;
-                    cbMonitor.SelectionChanged += DisplayComboBox_SelectionChanged;
                     // Rebuild our registration on the current edge/monitor (may have been disconnected).
                     if (fBarRegistered) relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
                     break;
@@ -924,19 +923,32 @@ namespace AppAppBar3
                           }
         }
 
-        private void DisplayComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
-            selectedItemsText = (cbMonitor.SelectedItem as String);
-        }
+        // Dock-menu handlers — set Edge in settings, sync the (still-present) edge
+        // ComboBox via its SelectionChanged path, and reposition the AppBar.
+        private void DockTop_Click(object sender, RoutedEventArgs e)    => SetEdge(ABEdge.Top);
+        private void DockRight_Click(object sender, RoutedEventArgs e)  => SetEdge(ABEdge.Right);
+        private void DockBottom_Click(object sender, RoutedEventArgs e) => SetEdge(ABEdge.Bottom);
+        private void DockLeft_Click(object sender, RoutedEventArgs e)   => SetEdge(ABEdge.Left);
 
+        private void SetEdge(ABEdge edge)
+        {
+            saveSetting("edge", (int)edge);
+            Edge = edge;
+            // Assigning SelectedItem fires edgeComboBox_SelectionChanged which
+            // does the actual ABSetPos call — no need to call relocateWindowLocation
+            // here. If the value is already selected, force the relocate manually.
+            if (edgeMonitor.SelectedItem is ABEdge cur && cur == edge)
+                relocateWindowLocation(edge);
+            else
+                edgeMonitor.SelectedItem = edge;
+        }
 
         private void relocateWindowLocation(ABEdge theSelectedEdge)
         {
             Debug.WriteLine("This is the edge var "+Edge);
-            
-           
-              ABSetPos(theSelectedEdge, cbMonitor.SelectedItem as string);
+
+
+              ABSetPos(theSelectedEdge, loadSettings("monitor") as string);
             if (Edge == ABEdge.Top || Edge == ABEdge.Bottom)
             {
                 Debug.WriteLine("Edge Selection " + Edge);
@@ -988,8 +1000,9 @@ namespace AppAppBar3
             bool isSettings = wappWindow.Title == "Settings";
 
             Monitor mon = null;
+            var savedMonitor = loadSettings("monitor") as string;
             foreach (var m in monitorInfo)
-                if (m.MonitorName == cbMonitor.SelectedItem as string) { mon = m; break; }
+                if (m.MonitorName == savedMonitor) { mon = m; break; }
             if (mon == null) return;
 
             int x, y, w, h;

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -450,7 +450,13 @@ namespace AppAppBar3
             // for dark mode. Out of order in the source enum because the Win10
             // header defined it long after DWMWA_LAST was named.
             DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
+            // Win32 attribute id 34 (Win11 Build 22000+): sets the window border
+            // color, or removes the border outright when set to DWMWA_COLOR_NONE
+            // (0xFFFFFFFE). Ignored on Win10 — call is a safe no-op there.
+            DWMWA_BORDER_COLOR = 34,
         }
+
+        public const uint DWMWA_COLOR_NONE = 0xFFFFFFFE;
         //remove window decorations by removing border, caption, titlebar etc
         //remove corner radius by removing border and caption, remove title bar
         public static void removeWindowDecoration(IntPtr hwnd)


### PR DESCRIPTION
Follow-up to #18.

## AppBar surface cleanup
- Right-click `ContextFlyout` now hosts the dock options. **Dock Top** (was missing) is added; Right / Bottom / Left moved over from the old CommandBar. Each item gets a `SymbolIcon` and is wired through new `DockTop_Click` / `DockRight_Click` / `DockBottom_Click` / `DockLeft_Click` handlers + a `SetEdge` helper that saves the new edge to settings and routes through the existing `edgeComboBox_SelectionChanged` path so `ABSetPos` runs once.
- **CommandBar removed entirely** — its remaining items (Identify Monitor, Settings, Close AppBar) already live in the context menu.
- **`cbMonitor` ComboBox removed** from the AppBar — monitor selection is in Settings, the AppBar reads `loadSettings("monitor")` directly.
- `DisplayComboBox_SelectionChanged` and all `cbMonitor` wiring deleted.

## Borderless retry — different mechanism
The previous attempt (#16/#17) used `OverlappedPresenter.SetBorderAndTitleBar(false, false)` which left the AppBar with no rendered XAML (#18 reverted it). This PR tries `DwmSetWindowAttribute(DWMWA_BORDER_COLOR = COLOR_NONE)` instead — Win11 22000+ accepts `0xFFFFFFFE` to disable the border outright, and it's a no-op on Win10. Unlike the presenter approach this only affects the DWM border paint, not the window styles or composition, so it shouldn't interact with the AppBar registration / `WS_CAPTION` strip.

Three files, +59 / −35.

## Test plan
- [ ] CI matrix green.
- [ ] AppBar surface shows: Web toggle, Edge dropdown, shortcuts. **No** monitor dropdown, **no** CommandBar.
- [ ] Right-click opens the menu with **Dock Top / Right / Bottom / Left**, separator, Identify Monitor / Settings, separator, Close AppBar.
- [ ] Each Dock item moves the AppBar to that edge and the choice persists across restarts.
- [ ] Identify Monitor still pops the per-monitor overlays; Settings still opens / light-dismisses; Close AppBar still exits.
- [ ] Border around the AppBar is gone on Win11. (On Win10 the call is a no-op — border may still be visible there.)

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_