### PR TITLE
Drop edge dropdown from AppBar; widen border-style strip

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -67,9 +67,6 @@
                 </ToggleButton>
 
 
-            <ComboBox x:Name="edgeMonitor"  Margin="5,9,5,0"  SelectedItem="{Binding Edge, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"  SelectionChanged="edgeComboBox_SelectionChanged"  PlaceholderText="Top" Width="{Binding ItemWidth, ElementName=layoutFlexGrid}" >
-
-                </ComboBox>
         </VariableSizedWrapGrid>
             
         </StackPanel>

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -130,11 +130,9 @@ namespace AppAppBar3
             this.AppWindow.IsShownInSwitchers = false;
             monitorInfo = GetMonitorsInfo();
             MonitorList = new ObservableCollection<Monitor>(GetMonitorsInfo());
-            edgeMonitor.DataContext = this;
             monitor = new WindowMessageMonitor(this);
             monitor.WindowMessageReceived += OnWindowMessageReceived;
             taskbarCreatedMsg = RegisterWindowMessage("TaskbarCreated");
-            edgeMonitor.ItemsSource = Enum.GetValues(typeof(ABEdge));
         }
        
 
@@ -150,7 +148,6 @@ namespace AppAppBar3
         private void OnActivated(object sender, Microsoft.UI.Xaml.WindowActivatedEventArgs args)
         {
 
-            edgeMonitor.SelectionChanged -= edgeComboBox_SelectionChanged;
             // selectedItemsText = @"\\.\DISPLAY1";
 
             if (appWindow == null)
@@ -164,7 +161,7 @@ namespace AppAppBar3
                     SettingMethods.setDefaultValues();
                 }
                 MigrateLegacyMonitorSetting();
-                edgeMonitor.SelectedItem = (ABEdge)loadSettings("edge");
+                Edge = (ABEdge)loadSettings("edge");
                
                 
                 Debug.WriteLine("Window activated edge from settings " + (ABEdge)loadSettings("edge"));
@@ -203,7 +200,6 @@ namespace AppAppBar3
                     }
 
                 }
-                edgeMonitor.SelectionChanged += edgeComboBox_SelectionChanged;
                 loadShortCuts();
 
                 
@@ -313,9 +309,7 @@ namespace AppAppBar3
             SHAppBarMessage((int)AppBarMessages.ABM_SETPOS, ref abd);
             ApplyThickness(ref abd.rc, edge, barSizeScaled);
 
-            IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
-            style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
-            SetWindowLong(hWnd, GWL_STYLE, style);
+            StripFrameStyles(hWnd);
             // SWP_FRAMECHANGED commits the style change and forces WM_NCCALCSIZE before
             // the move so the window doesn't retain non-client metrics from the old frame.
             SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0,
@@ -331,6 +325,22 @@ namespace AppAppBar3
             }
 
             SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
+        }
+
+        // Strips every standard / extended style that paints a window border or
+        // sunken edge. WS_CAPTION already covers WS_BORDER|WS_DLGFRAME; the
+        // extended styles cover the 1-px sunken / raised edges that survive a
+        // plain GWL_STYLE strip on some systems.
+        private static void StripFrameStyles(IntPtr hWnd)
+        {
+            IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
+            style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
+            SetWindowLong(hWnd, GWL_STYLE, style);
+
+            IntPtr ex = GetWindowLong(hWnd, GWL_EXSTYLE);
+            ex = (IntPtr)(ex.ToInt64() & ~(WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE
+                                          | WS_EX_STATICEDGE | WS_EX_DLGMODALFRAME));
+            SetWindowLong(hWnd, GWL_EXSTYLE, ex);
         }
 
         private static void ApplyThickness(ref RECT rc, ABEdge edge, int thickness)
@@ -416,9 +426,7 @@ namespace AppAppBar3
                 case ABEdge.Bottom: triggerRect.top    = mon.bottom - triggerPx; break;
             }
 
-            IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
-            style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
-            SetWindowLong(hWnd, GWL_STYLE, style);
+            StripFrameStyles(hWnd);
             SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 
@@ -594,7 +602,7 @@ namespace AppAppBar3
                 switch (e.Message.WParam)
                 {
                     case (int)ABNotify.ABN_POSCHANGED:
-                        relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
+                        relocateWindowLocation(Edge);
                         break;
 
                     case (int)ABNotify.ABN_FULLSCREENAPP:
@@ -644,7 +652,7 @@ namespace AppAppBar3
                 case WM_DISPLAYCHANGE:
                     MonitorList = new ObservableCollection<Monitor>(GetMonitorsInfo());
                     // Rebuild our registration on the current edge/monitor (may have been disconnected).
-                    if (fBarRegistered) relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
+                    if (fBarRegistered) relocateWindowLocation(Edge);
                     break;
             }
         }
@@ -923,8 +931,8 @@ namespace AppAppBar3
                           }
         }
 
-        // Dock-menu handlers — set Edge in settings, sync the (still-present) edge
-        // ComboBox via its SelectionChanged path, and reposition the AppBar.
+        // Dock-menu handlers — persist the new edge, update the bound Edge
+        // property, and reposition the AppBar.
         private void DockTop_Click(object sender, RoutedEventArgs e)    => SetEdge(ABEdge.Top);
         private void DockRight_Click(object sender, RoutedEventArgs e)  => SetEdge(ABEdge.Right);
         private void DockBottom_Click(object sender, RoutedEventArgs e) => SetEdge(ABEdge.Bottom);
@@ -934,13 +942,7 @@ namespace AppAppBar3
         {
             saveSetting("edge", (int)edge);
             Edge = edge;
-            // Assigning SelectedItem fires edgeComboBox_SelectionChanged which
-            // does the actual ABSetPos call — no need to call relocateWindowLocation
-            // here. If the value is already selected, force the relocate manually.
-            if (edgeMonitor.SelectedItem is ABEdge cur && cur == edge)
-                relocateWindowLocation(edge);
-            else
-                edgeMonitor.SelectedItem = edge;
+            relocateWindowLocation(edge);
         }
 
         private void relocateWindowLocation(ABEdge theSelectedEdge)
@@ -965,14 +967,6 @@ namespace AppAppBar3
             {
                 DockToAppBar(webWindow);
             }
-        }
-        private void edgeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-           Edge = ((ABEdge)edgeMonitor.SelectedItem);
-            Debug.WriteLine("This is the selecteditem edge "+Edge);
-            relocateWindowLocation((ABEdge)edgeMonitor.SelectedItem);
-            Debug.WriteLine("Edge Selection Changed********** "+ Edge);
-           
         }
         WebWindow webWindow;
         private void openWebWindow(object sender, RoutedEventArgs e)

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -13,8 +13,13 @@ namespace AppAppBar3
     {
 
         public const int GWL_STYLE = -16;
+        public const int GWL_EXSTYLE = -20;
         public const int WS_CAPTION = 0x00C00000;
         public const int WS_THICKFRAME = 0x00040000;
+        public const int WS_EX_DLGMODALFRAME = 0x00000001;
+        public const int WS_EX_WINDOWEDGE    = 0x00000100;
+        public const int WS_EX_CLIENTEDGE    = 0x00000200;
+        public const int WS_EX_STATICEDGE    = 0x00020000;
 
         [DllImport("shell32.dll", SetLastError = true)]
         public static extern IntPtr SHAppBarMessage(uint dwMessage, ref APPBARDATA pData);


### PR DESCRIPTION
Follow-up to #19.

## AppBar surface
Remove the **edge `ComboBox` (`edgeMonitor`)** from `MainWindow.xaml`. Dock Top / Right / Bottom / Left in the right-click menu (added in #19) cover the same function. The `Edge` property is still the single source of truth on the AppBar surface; `SetEdge` now updates `Edge` and calls `relocateWindowLocation` directly. Removed:
- `edgeMonitor.DataContext` / `ItemsSource` / `SelectionChanged ±=` wiring in the constructor and `OnActivated`.
- The `edgeComboBox_SelectionChanged` handler.
- `(ABEdge)edgeMonitor.SelectedItem` reads in the `ABN_POSCHANGED` and `WM_DISPLAYCHANGE` paths — replaced with the `Edge` property.

## Border (still present after #19)
`DWMWA_BORDER_COLOR = COLOR_NONE` only handles Win11's DWM-painted border. The 1-px frame the user is still seeing likely comes from an extended-style edge that survives a plain `GWL_STYLE` strip on some systems.

This PR extracts a `StripFrameStyles(hWnd)` helper and clears `WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE | WS_EX_DLGMODALFRAME` from `GWL_EXSTYLE` in addition to `WS_CAPTION | WS_THICKFRAME` from `GWL_STYLE`. Called from both `ApplyDocked` and `ApplyAutohide`.

Three files, +29 / −33.

## Test plan
- [ ] CI matrix green.
- [ ] AppBar surface shows Web toggle and shortcuts only — no edge dropdown, no monitor dropdown, no CommandBar.
- [ ] Right-click → Dock Top/Right/Bottom/Left still moves the bar; choice persists across restarts.
- [ ] Border around the AppBar is gone (or visibly thinner). If still visible, a screenshot would help pick the next angle (DWM frame extension, XAML root padding, or the WindowEx backdrop).

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_