### PR TITLE
Suppress residual AppBar border via DwmExtendFrameIntoClientArea

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -341,6 +341,12 @@ namespace AppAppBar3
             ex = (IntPtr)(ex.ToInt64() & ~(WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE
                                           | WS_EX_STATICEDGE | WS_EX_DLGMODALFRAME));
             SetWindowLong(hWnd, GWL_EXSTYLE, ex);
+
+            // Tell DWM not to extend any glass/frame into the client area. With the
+            // style strips above, this eliminates the residual 1-px non-client paint
+            // that survives WS_CAPTION/WS_THICKFRAME removal.
+            var noFrame = new MARGINS();
+            DwmExtendFrameIntoClientArea(hWnd, ref noFrame);
         }
 
         private static void ApplyThickness(ref RECT rc, ABEdge edge, int thickness)

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -432,6 +432,18 @@ namespace AppAppBar3
         [DllImport("dwmapi.dll")]
         public static extern int DwmSetWindowAttribute(IntPtr hwnd, DwmWindowAttribute dwAttribute, ref int pvAttribute, int cbAttribute);
 
+        [DllImport("dwmapi.dll")]
+        public static extern int DwmExtendFrameIntoClientArea(IntPtr hWnd, ref MARGINS pMarInset);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MARGINS
+        {
+            public int cxLeftWidth;
+            public int cxRightWidth;
+            public int cyTopHeight;
+            public int cyBottomHeight;
+        }
+
         [Flags]
         public enum DwmWindowAttribute : uint
         {


### PR DESCRIPTION
Follow-up to #20 (still showing a thin border per user screenshot of AppBar docked top).

## What's left of the border
After the `WS_CAPTION | WS_THICKFRAME` strip on `GWL_STYLE` and the `WS_EX_WINDOWEDGE | CLIENTEDGE | STATICEDGE | DLGMODALFRAME` clears on `GWL_EXSTYLE`, the residual 1-px paint is **DWM's frame**, not a window style. The targeted fix is `DwmExtendFrameIntoClientArea` with all-zero margins, which tells DWM not to extend any glass into the client area.

## Change
- `NativeMethods.cs`: P/Invoke for `DwmExtendFrameIntoClientArea` and the `MARGINS` struct.
- `MainWindow.xaml.cs`: `StripFrameStyles` now calls it with all-zero `MARGINS` after the style + extended-style strips. Both `ApplyDocked` and `ApplyAutohide` go through `StripFrameStyles` so this applies to both modes.

Two files, +18 / 0.

## Test plan
- [ ] CI green.
- [ ] AppBar docked at any edge shows no border.
- [ ] No regression in autohide rectangles.

If this still shows a border, the next angle is the small drag indicator that's visible near top-center in the screenshot — likely a `WindowEx` custom title-bar drag region; would address with `appWindow.TitleBar.ExtendsContentIntoTitleBar = true` and a transparent background.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_