### PR TITLE
Disable DWM NC rendering on AppBar; fix WebWindow top clipping

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -342,9 +342,15 @@ namespace AppAppBar3
                                           | WS_EX_STATICEDGE | WS_EX_DLGMODALFRAME));
             SetWindowLong(hWnd, GWL_EXSTYLE, ex);
 
-            // Tell DWM not to extend any glass/frame into the client area. With the
-            // style strips above, this eliminates the residual 1-px non-client paint
-            // that survives WS_CAPTION/WS_THICKFRAME removal.
+            // Tell DWM not to render non-client area for this window at all. This
+            // is stronger than DwmExtendFrameIntoClientArea(0,0,0,0): NCRENDERING_POLICY
+            // = DISABLED suppresses DWM's frame paint outright. The earlier extend
+            // call wasn't enough on its own to remove the residual 1-px border.
+            int ncrp = 1; // DWMNCRP_DISABLED
+            DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_NCRENDERING_POLICY, ref ncrp, sizeof(int));
+
+            // Tell DWM not to extend any glass/frame into the client area. Belt-and-
+            // suspenders alongside NCRENDERING_POLICY above.
             var noFrame = new MARGINS();
             DwmExtendFrameIntoClientArea(hWnd, ref noFrame);
         }
@@ -999,9 +1005,13 @@ namespace AppAppBar3
             var wappWindow = webW.GetAppWindow();
             bool isSettings = wappWindow.Title == "Settings";
 
+            // Re-query monitor info every time. The constructor-time monitorInfo was
+            // captured before our AppBar registered, so its WorkRect doesn't subtract
+            // our reservation — using it here would overlap WebWindow with the AppBar.
+            var fresh = GetMonitorsInfo();
             Monitor mon = null;
             var savedMonitor = loadSettings("monitor") as string;
-            foreach (var m in monitorInfo)
+            foreach (var m in fresh)
                 if (m.MonitorName == savedMonitor) { mon = m; break; }
             if (mon == null) return;
 


### PR DESCRIPTION
Two fixes after #21 testing.

## 1. Border still visible — try `DWMWA_NCRENDERING_POLICY`
`DwmExtendFrameIntoClientArea(0,0,0,0)` from #21 didn't suppress the residual 1-px border (user confirmed in packaged build, not just the VS dev artifact). Stronger DWM hammer: set `DWMWA_NCRENDERING_POLICY` to `DWMNCRP_DISABLED` (1) on the AppBar HWND, which makes DWM skip non-client rendering for this window outright. The frame-extension call from #21 stays as belt-and-suspenders.

If a thin line still shows after this, next stops are: zeroing `DWMWA_CAPTION_COLOR` / using `WS_POPUP` style explicitly, or wrapping the StackPanel in a `Border` with a small negative margin.

## 2. WebWindow top is cut off
`monitorInfo` is captured in `MainWindow`'s constructor — **before** the AppBar's `SHAppBarMessage(ABM_NEW)` / `ABM_SETPOS` calls reserve work area. Its `WorkRect` therefore still includes the strip our AppBar now occupies, so when `DockToAppBar` positions the WebWindow it puts the top edge of WebWindow under the AppBar (TOPMOST) and the user sees the top clipped.

Fix: re-query `MonitorHelper.GetMonitorsInfo()` inside `DockToAppBar` so the per-call `WorkRect` reflects the current reservation. Cheap (only runs when the WebWindow or Settings is opened) and correct under autohide / edge changes.

One file, +14 / −4.

## Test plan
- [ ] CI green.
- [ ] AppBar in packaged build — no visible 1-px border.
- [ ] Click Web on a Top-docked AppBar — WebWindow's top edge sits flush at the bottom of the AppBar, no clipping.
- [ ] Same with Edge = Bottom / Left / Right.
- [ ] Settings docking against the bar still works (uses `appWindow.Position`, not the work area).

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_