### PR TITLE
Backstop AppBar fill with outer Grid; square Win11 corners

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -17,7 +17,14 @@
     Closed="appbarWindow_Closed">
 
 
-    <StackPanel x:Name="stPanel" Background="{ThemeResource SystemChromeMediumLowColor}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Horizontal" AllowDrop="True" DragOver="Grid_DragOver" DragLeave="DragLeave" Drop="Grid_Drop" CanDrag="True">
+    <!--
+        Outer Grid backstops the chrome color across the entire client area so a
+        1-px gap at the window edges (where the StackPanel doesn't quite reach)
+        can't leak the default window background and read as a "border".
+        The StackPanel still handles drag/drop and hosts the context menu.
+    -->
+    <Grid Background="{ThemeResource SystemChromeMediumLowColor}">
+    <StackPanel x:Name="stPanel" Background="{ThemeResource SystemChromeMediumLowColor}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0" Padding="0" Orientation="Horizontal" AllowDrop="True" DragOver="Grid_DragOver" DragLeave="DragLeave" Drop="Grid_Drop" CanDrag="True">
         <StackPanel.ContextFlyout>
             <MenuFlyout>
                 <MenuFlyoutItem Text="Dock Top" Click="DockTop_Click">
@@ -70,9 +77,5 @@
         </VariableSizedWrapGrid>
             
         </StackPanel>
-        
-
-
-
-
+    </Grid>
 </winex:WindowEx>

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -349,6 +349,11 @@ namespace AppAppBar3
             int ncrp = 1; // DWMNCRP_DISABLED
             DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_NCRENDERING_POLICY, ref ncrp, sizeof(int));
 
+            // Win11: square the corners. Rounded-corner anti-aliasing at the screen-
+            // edge corners reads as a thin gap when the AppBar is docked tight.
+            int corner = DWMWCP_DONOTROUND;
+            DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
+
             // Tell DWM not to extend any glass/frame into the client area. Belt-and-
             // suspenders alongside NCRENDERING_POLICY above.
             var noFrame = new MARGINS();

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -471,9 +471,14 @@ namespace AppAppBar3
             // color, or removes the border outright when set to DWMWA_COLOR_NONE
             // (0xFFFFFFFE). Ignored on Win10 — call is a safe no-op there.
             DWMWA_BORDER_COLOR = 34,
+            // Win11 22000+: 0=default, 1=donotround, 2=round, 3=roundsmall.
+            // Setting DONOTROUND on the docked AppBar removes any rounded-corner
+            // anti-aliasing that can read as a thin border at the screen-edge corners.
+            DWMWA_WINDOW_CORNER_PREFERENCE = 33,
         }
 
         public const uint DWMWA_COLOR_NONE = 0xFFFFFFFE;
+        public const int DWMWCP_DONOTROUND = 1;
         //remove window decorations by removing border, caption, titlebar etc
         //remove corner radius by removing border and caption, remove title bar
         public static void removeWindowDecoration(IntPtr hwnd)


### PR DESCRIPTION
Follow-up to #22 — border still visible after `DWMWA_NCRENDERING_POLICY = DISABLED`. Two angles in this PR.

## 1. XAML root fills the client area
Hypothesis (and the user's read): the visible 1-px line is the default Window background showing through where the StackPanel doesn't quite reach. Wrap the StackPanel in a `Grid` with the same `SystemChromeMediumLowColor` brush so the chrome paint always covers the full client area, regardless of where the StackPanel ends. Explicit `Margin="0"` / `Padding="0"` on the StackPanel as belt-and-suspenders.

## 2. Square corners on Win11
Win11 rounds window corners by default (anti-aliased). On a docked AppBar the rounded corner where the bar meets the screen edge reads as a thin gap. Set `DWMWA_WINDOW_CORNER_PREFERENCE = DWMWCP_DONOTROUND` (attribute 33, value 1). Ignored on Win10.

Three files, +19 / −6.

## Test plan
- [ ] CI green.
- [ ] AppBar in packaged build at any edge — no visible border.
- [ ] Rounded-corner artifact at screen-edge corners gone (Win11).
- [ ] No regression in WebWindow positioning (#22).

If a thin line is *still* there, last reasonable angle is to inspect what root element WinUI 3 injects above our content and whether it's painting a default-themed background.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_