### PR TITLE
Diagnostic: drop IsTitleBarVisible to test WinUIEx as border source

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -9,7 +9,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    IsTitleBarVisible="False"
     IsShownInSwitchers="False"
     IsAlwaysOnTop="True"
     MinHeight="25"


### PR DESCRIPTION
**Diagnostic** PR — confirming the source of the residual AppBar border before patching it.

## Hypothesis
WinUIEx implements `IsTitleBarVisible="False"` by calling `OverlappedPresenter.SetBorderAndTitleBar(true, false)` — i.e. it **explicitly enables the presenter's 1-px border**. If true, no Win32 / DWM attribute strip can override it, because the presenter re-asserts on every layout pass. That would explain why every angle in PRs #20–#23 (`WS_CAPTION` / `WS_THICKFRAME` strip, `WS_EX_*` clears, `DWMWA_BORDER_COLOR=COLOR_NONE`, `DWMWA_NCRENDERING_POLICY=DISABLED`, `DwmExtendFrameIntoClientArea`, corner squaring, outer Grid backstop) failed to remove the visible line.

## Change
Single deletion: `IsTitleBarVisible="False"` from `MainWindow.xaml`. Nothing else.

## Test plan — pick one outcome
- **Border vanishes** (a real title bar will appear above the bar): WinUIEx is the source. Follow-up PR will drop `IsTitleBarVisible` entirely and instead call `op.SetBorderAndTitleBar(false, false)` ourselves *after* `ABSetPos` completes in `relocateWindowLocation` — the timing that previously broke (#16/#17/#18) was *before* the AppBar registration. After-registration timing is the unexplored angle.
- **Border still there, with title bar above it**: WinUIEx isn't the source. This PR gets reverted and we'd need to instrument the actual rendered tree (Live Visual Tree from VS, or a `Microsoft.UI.Xaml.Markup.XamlReader`-based dump) to find what's painting it.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_