### PR TITLE
Clean up dead border-suppression code

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -16,14 +16,7 @@
     Closed="appbarWindow_Closed">
 
 
-    <!--
-        Outer Grid backstops the chrome color across the entire client area so a
-        1-px gap at the window edges (where the StackPanel doesn't quite reach)
-        can't leak the default window background and read as a "border".
-        The StackPanel still handles drag/drop and hosts the context menu.
-    -->
-    <Grid Background="{ThemeResource SystemChromeMediumLowColor}">
-    <StackPanel x:Name="stPanel" Background="{ThemeResource SystemChromeMediumLowColor}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0" Padding="0" Orientation="Horizontal" AllowDrop="True" DragOver="Grid_DragOver" DragLeave="DragLeave" Drop="Grid_Drop" CanDrag="True">
+    <StackPanel x:Name="stPanel" Background="{ThemeResource SystemChromeMediumLowColor}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Horizontal" AllowDrop="True" DragOver="Grid_DragOver" DragLeave="DragLeave" Drop="Grid_Drop" CanDrag="True">
         <StackPanel.ContextFlyout>
             <MenuFlyout>
                 <MenuFlyoutItem Text="Dock Top" Click="DockTop_Click">
@@ -76,5 +69,4 @@
         </VariableSizedWrapGrid>
             
         </StackPanel>
-    </Grid>
 </winex:WindowEx>

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -173,13 +173,6 @@ namespace AppAppBar3
                     int value = 0x01;
                     int hr = DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_EXCLUDED_FROM_PEEK, ref value, Marshal.SizeOf(typeof(int)));
 
-                    // Suppress the residual 1-px window frame that Win11 paints even
-                    // after WS_CAPTION/WS_THICKFRAME are stripped. DWMWA_BORDER_COLOR
-                    // accepts DWMWA_COLOR_NONE to disable the border outright.
-                    // Ignored on Win10 — call is a safe no-op.
-                    int noBorder = unchecked((int)DWMWA_COLOR_NONE);
-                    DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_BORDER_COLOR, ref noBorder, Marshal.SizeOf(typeof(int)));
-
                 // Ensure we only register the app bar once
                 if (args.WindowActivationState != WindowActivationState.Deactivated)
                 {
@@ -327,37 +320,13 @@ namespace AppAppBar3
             SHAppBarMessage((int)AppBarMessages.ABM_WINDOWPOSCHANGED, ref abd);
         }
 
-        // Strips every standard / extended style that paints a window border or
-        // sunken edge. WS_CAPTION already covers WS_BORDER|WS_DLGFRAME; the
-        // extended styles cover the 1-px sunken / raised edges that survive a
-        // plain GWL_STYLE strip on some systems.
+        // Strips WS_CAPTION (covers WS_BORDER|WS_DLGFRAME) and WS_THICKFRAME so the
+        // docked AppBar has no caption, no sizing frame, and no system-painted edge.
         private static void StripFrameStyles(IntPtr hWnd)
         {
             IntPtr style = GetWindowLong(hWnd, GWL_STYLE);
             style = (IntPtr)(style.ToInt64() & ~(WS_CAPTION | WS_THICKFRAME));
             SetWindowLong(hWnd, GWL_STYLE, style);
-
-            IntPtr ex = GetWindowLong(hWnd, GWL_EXSTYLE);
-            ex = (IntPtr)(ex.ToInt64() & ~(WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE
-                                          | WS_EX_STATICEDGE | WS_EX_DLGMODALFRAME));
-            SetWindowLong(hWnd, GWL_EXSTYLE, ex);
-
-            // Tell DWM not to render non-client area for this window at all. This
-            // is stronger than DwmExtendFrameIntoClientArea(0,0,0,0): NCRENDERING_POLICY
-            // = DISABLED suppresses DWM's frame paint outright. The earlier extend
-            // call wasn't enough on its own to remove the residual 1-px border.
-            int ncrp = 1; // DWMNCRP_DISABLED
-            DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_NCRENDERING_POLICY, ref ncrp, sizeof(int));
-
-            // Win11: square the corners. Rounded-corner anti-aliasing at the screen-
-            // edge corners reads as a thin gap when the AppBar is docked tight.
-            int corner = DWMWCP_DONOTROUND;
-            DwmSetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
-
-            // Tell DWM not to extend any glass/frame into the client area. Belt-and-
-            // suspenders alongside NCRENDERING_POLICY above.
-            var noFrame = new MARGINS();
-            DwmExtendFrameIntoClientArea(hWnd, ref noFrame);
         }
 
         private static void ApplyThickness(ref RECT rc, ABEdge edge, int thickness)

--- a/AppAppBar3/NativeMethods.cs
+++ b/AppAppBar3/NativeMethods.cs
@@ -13,13 +13,8 @@ namespace AppAppBar3
     {
 
         public const int GWL_STYLE = -16;
-        public const int GWL_EXSTYLE = -20;
         public const int WS_CAPTION = 0x00C00000;
         public const int WS_THICKFRAME = 0x00040000;
-        public const int WS_EX_DLGMODALFRAME = 0x00000001;
-        public const int WS_EX_WINDOWEDGE    = 0x00000100;
-        public const int WS_EX_CLIENTEDGE    = 0x00000200;
-        public const int WS_EX_STATICEDGE    = 0x00020000;
 
         [DllImport("shell32.dll", SetLastError = true)]
         public static extern IntPtr SHAppBarMessage(uint dwMessage, ref APPBARDATA pData);
@@ -432,18 +427,6 @@ namespace AppAppBar3
         [DllImport("dwmapi.dll")]
         public static extern int DwmSetWindowAttribute(IntPtr hwnd, DwmWindowAttribute dwAttribute, ref int pvAttribute, int cbAttribute);
 
-        [DllImport("dwmapi.dll")]
-        public static extern int DwmExtendFrameIntoClientArea(IntPtr hWnd, ref MARGINS pMarInset);
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct MARGINS
-        {
-            public int cxLeftWidth;
-            public int cxRightWidth;
-            public int cyTopHeight;
-            public int cyBottomHeight;
-        }
-
         [Flags]
         public enum DwmWindowAttribute : uint
         {
@@ -467,18 +450,7 @@ namespace AppAppBar3
             // for dark mode. Out of order in the source enum because the Win10
             // header defined it long after DWMWA_LAST was named.
             DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
-            // Win32 attribute id 34 (Win11 Build 22000+): sets the window border
-            // color, or removes the border outright when set to DWMWA_COLOR_NONE
-            // (0xFFFFFFFE). Ignored on Win10 — call is a safe no-op there.
-            DWMWA_BORDER_COLOR = 34,
-            // Win11 22000+: 0=default, 1=donotround, 2=round, 3=roundsmall.
-            // Setting DONOTROUND on the docked AppBar removes any rounded-corner
-            // anti-aliasing that can read as a thin border at the screen-edge corners.
-            DWMWA_WINDOW_CORNER_PREFERENCE = 33,
         }
-
-        public const uint DWMWA_COLOR_NONE = 0xFFFFFFFE;
-        public const int DWMWCP_DONOTROUND = 1;
         //remove window decorations by removing border, caption, titlebar etc
         //remove corner radius by removing border and caption, remove title bar
         public static void removeWindowDecoration(IntPtr hwnd)


### PR DESCRIPTION
Cleanup follow-up to #24 (the actual border fix). All the border-suppression code added across PRs #20–#23 turned out to be unrelated to the real cause (`IsTitleBarVisible="False"` triggering `SetBorderAndTitleBar(true, false)` in WinUIEx). Removing it so the AppBar path stays minimal and easy to reason about.

## Removals
**`StripFrameStyles`** — back to just the original `WS_CAPTION | WS_THICKFRAME` strip on `GWL_STYLE`. Removed:
- `WS_EX_WINDOWEDGE | CLIENTEDGE | STATICEDGE | DLGMODALFRAME` clear on `GWL_EXSTYLE`.
- `DWMWA_NCRENDERING_POLICY = DISABLED` call.
- `DWMWA_WINDOW_CORNER_PREFERENCE = DWMWCP_DONOTROUND` call.
- `DwmExtendFrameIntoClientArea(0,0,0,0)` call.

**`OnActivated`** — drop the `DWMWA_BORDER_COLOR = DWMWA_COLOR_NONE` call.

**`MainWindow.xaml`** — unwrap the outer Grid backstop and drop the `Margin="0" / Padding="0"` overrides on `stPanel`.

**`NativeMethods.cs`** — remove `GWL_EXSTYLE`, the four `WS_EX_*` constants, the `MARGINS` struct, the `DwmExtendFrameIntoClientArea` P/Invoke, the `DWMWA_BORDER_COLOR` / `DWMWA_WINDOW_CORNER_PREFERENCE` enum entries, and the `DWMWA_COLOR_NONE` / `DWMWCP_DONOTROUND` constants.

## Kept
- `monitorInfo` re-query in `DockToAppBar` (#22) — fixed a real WebWindow top-clipping bug.
- `DWMWA_USE_IMMERSIVE_DARK_MODE` — used by `ThemeHelper.ApplyImmersiveDarkMode`.
- `DWMWA_EXCLUDED_FROM_PEEK` — Aero Peek exclusion.

Three files, +4 / −71.

## Test plan
- [ ] CI green.
- [ ] AppBar still has no visible border.
- [ ] AppBar at any edge still docks correctly with the WS_CAPTION strip alone.
- [ ] WebWindow still positions flush against the AppBar (no top-clipping regression).
- [ ] Theme switching still tints the AppBar caption (immersive dark mode call still works).

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_