### PR TITLE
Scale AppBar controls with bar_size; orient with edge

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -194,8 +194,7 @@ namespace AppAppBar3
 
                 }
                 loadShortCuts();
-
-                
+                RescaleControls();
             }
 
         }
@@ -766,11 +765,12 @@ namespace AppAppBar3
                 };
                 bi.SetSource(iconThumbnail);
 
+                double iconSize = CurrentIconSize;
                 Image ButtonImageEL = new Image()
                 {
                     Source = bi,
-                    Height = 32,
-                    Width = 32,
+                    Height = iconSize,
+                    Width = iconSize,
                  };
 
                 Button testIButton = new Button()
@@ -858,8 +858,64 @@ namespace AppAppBar3
         public void restartAppBar()
         {
             ABSetPos((ABEdge)SettingMethods.loadSettings("edge"), (string)SettingMethods.loadSettings("monitor"));
-            //ABSetPos(theSelectedEdge, cbMonitor.SelectedItem as string);
+            RescaleControls();
+        }
 
+        // Visual scaling baseline matches bar_size = 50: at scale 1.0 controls
+        // keep their original sizes. Smaller bars shrink controls/text/icons
+        // proportionally; larger bars grow them. Also updates VariableGrid and
+        // stPanel orientation so children flow along the bar's long axis.
+        private const int BaselineBarSize = 50;
+        private const double BaselineFontSize = 14;
+        private const double BaselineIconSize = 32;
+
+        private double CurrentScale
+        {
+            get
+            {
+                int barSize = (loadSettings("bar_size") as int?) ?? BaselineBarSize;
+                return (double)barSize / BaselineBarSize;
+            }
+        }
+
+        private double CurrentIconSize => BaselineIconSize * CurrentScale;
+
+        private void RescaleControls()
+        {
+            int barSize = (loadSettings("bar_size") as int?) ?? BaselineBarSize;
+            double scale = (double)barSize / BaselineBarSize;
+            bool horizontal = Edge == ABEdge.Top || Edge == ABEdge.Bottom;
+
+            stPanel.Orientation = horizontal ? Orientation.Horizontal : Orientation.Vertical;
+
+            if (horizontal)
+            {
+                // Horizontal bar: item height matches bar thickness, items wider for text.
+                VariableGrid.Orientation = Orientation.Horizontal;
+                VariableGrid.ItemHeight = barSize;
+                VariableGrid.ItemWidth  = barSize * 2;
+            }
+            else
+            {
+                // Vertical bar: square cells stack down the bar's width.
+                VariableGrid.Orientation = Orientation.Vertical;
+                VariableGrid.ItemWidth  = barSize;
+                VariableGrid.ItemHeight = barSize;
+            }
+
+            webButton.FontSize = BaselineFontSize * scale;
+
+            // Shortcut buttons live as direct children of stPanel (not VariableGrid);
+            // scale their Image content so the button auto-sizes to match.
+            double iconSize = CurrentIconSize;
+            foreach (var child in stPanel.Children)
+            {
+                if (child is Button btn && btn.Content is Image img)
+                {
+                    img.Width  = iconSize;
+                    img.Height = iconSize;
+                }
+            }
         }
         Settings settingsWindow;
 
@@ -933,22 +989,8 @@ namespace AppAppBar3
 
         private void relocateWindowLocation(ABEdge theSelectedEdge)
         {
-            Debug.WriteLine("This is the edge var "+Edge);
-
-
-              ABSetPos(theSelectedEdge, loadSettings("monitor") as string);
-            if (Edge == ABEdge.Top || Edge == ABEdge.Bottom)
-            {
-                Debug.WriteLine("Edge Selection " + Edge);
-
-                stPanel.Orientation = Orientation.Horizontal;
-            }
-            else
-            {
-                stPanel.Orientation = Orientation.Vertical;
-            }
-
-           
+            ABSetPos(theSelectedEdge, loadSettings("monitor") as string);
+            RescaleControls();
             if (webWindow != null)
             {
                 DockToAppBar(webWindow);


### PR DESCRIPTION
## What it does
- **Scaling**: `bar_size = 50` is the visual baseline (scale 1.0). At smaller sizes the Web toggle's font, shortcut icons, and `VariableGrid` cell sizes shrink proportionally; at larger sizes they grow.
- **Orientation**: when the AppBar is docked Top / Bottom, `stPanel` and `VariableGrid` flow Horizontal with cells `barSize × 2*barSize`. When docked Left / Right, both flow Vertical with square `barSize × barSize` cells.

## Implementation
New `RescaleControls()` method in `MainWindow.xaml.cs` plus two helpers (`CurrentScale`, `CurrentIconSize`). Called from:
- `relocateWindowLocation` — when the edge changes (replaces the inline orientation toggle that was there).
- `restartAppBar` — when `bar_size` changes via Settings.
- End of `OnActivated` — once at startup so the bar reflects the saved settings on first paint.

`createShortCut` now constructs the new `Image` using `CurrentIconSize` so freshly-dropped icons match the current scale immediately. Existing shortcuts are re-sized in `RescaleControls`'s loop over `stPanel.Children`.

One file, +63 / −21.

## Test plan
- [ ] CI green.
- [ ] At `bar_size = 50`, layout matches today's appearance.
- [ ] Bump bar_size to 100 in Settings -> Apply: bar thickness doubles, Web text grows, shortcut icons grow.
- [ ] Drop bar_size to 25 -> everything shrinks proportionally.
- [ ] Right-click -> Dock Left: bar goes vertical, shortcut icons stay square, items stack down the bar.
- [ ] Right-click -> Dock Top after that: returns to horizontal, items flow left to right.
- [ ] Add a new shortcut at small bar size -> icon comes in at the smaller size, not 32px.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_