### PR TITLE
Replace Web text button with transparent globe icon

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -61,9 +61,12 @@
 
             <VariableSizedWrapGrid Orientation="Horizontal"  x:Name="VariableGrid" AllowDrop="False" DragOver="Grid_DragOver" Drop="Grid_Drop" CanDrag="True" MaximumRowsOrColumns="120" ItemHeight="50" ItemWidth="100" HorizontalAlignment="Left" HorizontalChildrenAlignment="Left" >
 
-            <ToggleButton  x:Name="webButton" Content="Web" Click="openWebWindow" Width="{Binding ItemWidth, ElementName=VariableGrid}">
-
-                </ToggleButton>
+            <ToggleButton x:Name="webButton" Click="openWebWindow"
+                          Background="Transparent" BorderBrush="Transparent"
+                          Padding="0"
+                          Width="{Binding ItemWidth, ElementName=VariableGrid}">
+                <SymbolIcon x:Name="webIcon" Symbol="Globe"/>
+            </ToggleButton>
 
 
         </VariableSizedWrapGrid>

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -866,7 +866,6 @@ namespace AppAppBar3
         // proportionally; larger bars grow them. Also updates VariableGrid and
         // stPanel orientation so children flow along the bar's long axis.
         private const int BaselineBarSize = 50;
-        private const double BaselineFontSize = 14;
         private const double BaselineIconSize = 32;
 
         private double CurrentScale
@@ -903,7 +902,9 @@ namespace AppAppBar3
                 VariableGrid.ItemHeight = barSize;
             }
 
-            webButton.FontSize = BaselineFontSize * scale;
+            // SymbolIcon size is driven by its own FontSize (it doesn't inherit
+            // from the parent ToggleButton). Default SymbolIcon FontSize is 20.
+            webIcon.FontSize = 20 * scale;
 
             // Shortcut buttons live as direct children of stPanel (not VariableGrid);
             // scale their Image content so the button auto-sizes to match.


### PR DESCRIPTION
## Change
- `ToggleButton` x:Name="webButton" now hosts a `SymbolIcon` (`Symbol="Globe"`) in place of `Content="Web"`.
- `Background="Transparent"`, `BorderBrush="Transparent"`, `Padding="0"` — the button reads as just the icon. Framework hover / pressed overlays still provide click feedback.
- `RescaleControls` scales `webIcon.FontSize` directly (SymbolIcon doesn't inherit `FontSize` from its parent ToggleButton). Baseline `20 px` at `bar_size = 50`; `webIcon.FontSize = 20 * scale` for any other size.
- Drop the now-unused `BaselineFontSize` constant.

Two files, +9 / −5.

## Test plan
- [ ] CI green.
- [ ] AppBar shows a globe icon where the "Web" button was, with no visible button background or border.
- [ ] Click the icon — opens / closes the WebWindow same as before.
- [ ] Bar size 50 → icon at default size; 100 → ~2× bigger; 25 → half. No clipping or layout shift.
- [ ] Vertical bar (Dock Left / Right) — icon still centered in its cell.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_