### PR TITLE
Switch web icon to FontIcon so it has a FontSize to scale

### DIFF
--- a/AppAppBar3/MainWindow.xaml
+++ b/AppAppBar3/MainWindow.xaml
@@ -65,7 +65,7 @@
                           Background="Transparent" BorderBrush="Transparent"
                           Padding="0"
                           Width="{Binding ItemWidth, ElementName=VariableGrid}">
-                <SymbolIcon x:Name="webIcon" Symbol="Globe"/>
+                <FontIcon x:Name="webIcon" Glyph="&#xE774;"/>
             </ToggleButton>
 
 

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -902,8 +902,8 @@ namespace AppAppBar3
                 VariableGrid.ItemHeight = barSize;
             }
 
-            // SymbolIcon size is driven by its own FontSize (it doesn't inherit
-            // from the parent ToggleButton). Default SymbolIcon FontSize is 20.
+            // FontIcon size is driven by its own FontSize property (SymbolIcon
+            // doesn't expose one). Default FontIcon FontSize is 20.
             webIcon.FontSize = 20 * scale;
 
             // Shortcut buttons live as direct children of stPanel (not VariableGrid);


### PR DESCRIPTION
Build fix for #27. The web-icon button used `<SymbolIcon Symbol="Globe"/>` and `RescaleControls` then assigned `webIcon.FontSize = 20 * scale`, which fails to compile under WinUI 3:

```
CS1061: 'SymbolIcon' does not contain a definition for 'FontSize'
```

`FontSize` lives on `FontIcon`, not `SymbolIcon`. Switched to `<FontIcon Glyph="&#xE774;"/>` — same code point `Symbol.Globe` internally resolves to in Segoe Fluent Icons, so the visual is unchanged. `FontIcon.FontSize` is settable, so the scale assignment compiles and the icon scales with `bar_size` as intended.

Two files, +3 / −3.

## Test plan
- [ ] CI matrix green (the previous push failed compile).
- [ ] Globe icon visible in place of the Web button, no background/border.
- [ ] Icon scales with `bar_size` (try 25 / 50 / 100).

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_