### PR TITLE
Add taskbar-style translucent AppBar background option

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -195,6 +195,7 @@ namespace AppAppBar3
                 }
                 loadShortCuts();
                 RescaleControls();
+                ApplyBackdropPreference();
             }
 
         }
@@ -859,6 +860,35 @@ namespace AppAppBar3
         {
             ABSetPos((ABEdge)SettingMethods.loadSettings("edge"), (string)SettingMethods.loadSettings("monitor"));
             RescaleControls();
+            ApplyBackdropPreference();
+        }
+
+        // Translucent ("taskbar-like") AppBar background. Only takes effect when
+        // the user is following the Windows theme — explicit Light/Dark uses the
+        // existing solid chrome fill so the user's color choice isn't tinted.
+        public void ApplyBackdropPreference()
+        {
+            bool wantTransparent = (loadSettings("transparency") as bool?) ?? false;
+            bool themeIsDefault = ThemeHelper.LoadSavedTheme() == ElementTheme.Default;
+            bool useBackdrop = wantTransparent && themeIsDefault;
+
+            if (useBackdrop)
+            {
+                if (this.SystemBackdrop == null)
+                    this.SystemBackdrop = new DesktopAcrylicBackdrop();
+                stPanel.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            }
+            else
+            {
+                this.SystemBackdrop = null;
+                // Restore the chrome fill. Walk stPanel-local resources first, then
+                // fall back to the app-level dictionary; either returns the active
+                // theme's value at this moment.
+                if (!stPanel.Resources.TryGetValue("SystemChromeMediumLowColor", out var res))
+                    Application.Current.Resources.TryGetValue("SystemChromeMediumLowColor", out res);
+                if (res is Windows.UI.Color color)
+                    stPanel.Background = new SolidColorBrush(color);
+            }
         }
 
         // Visual scaling baseline matches bar_size = 50: at scale 1.0 controls

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -65,6 +65,7 @@ namespace AppAppBar3
             saveSetting("edge", 1);
             saveSetting("autohide", false);
             saveSetting("theme", "Default");
+            saveSetting("transparency", false);
         }
 
         public static void saveSetting(string setting, object value)

--- a/AppAppBar3/Settings.xaml
+++ b/AppAppBar3/Settings.xaml
@@ -10,11 +10,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="Settings"
-    Height="450"
+    Height="490"
     Width="300"
     IsShownInSwitchers="False">
 
-    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="450" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
+    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="490" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
         
           
         <TextBlock Margin="10,10,0,0">Startup Edge:</TextBlock>
@@ -36,6 +36,7 @@
             <CheckBox x:Name="autohideCheckBox" Click="autohideCheckBox_Click" Margin="10,10,0,0" Content="Auto-hide" IsTabStop="False"></CheckBox>
             <TextBlock Margin="10,10,0,0">Theme:</TextBlock>
             <ComboBox x:Name="cbThemeSettings" Margin="10,10,0,0" Width="200" MinWidth="200" SelectionChanged="cbThemeSettings_SelectionChanged"/>
+            <CheckBox x:Name="transparencyCheckBox" Click="transparencyCheckBox_Click" Margin="10,10,0,0" Content="Translucent background (Theme = Default)" IsTabStop="False"/>
         
 
 

--- a/AppAppBar3/Settings.xaml.cs
+++ b/AppAppBar3/Settings.xaml.cs
@@ -68,6 +68,8 @@ namespace AppAppBar3
             cbThemeSettings.ItemsSource = Enum.GetNames(typeof(ElementTheme));
             cbThemeSettings.SelectedItem = ThemeHelper.LoadSavedTheme().ToString();
             cbThemeSettings.SelectionChanged += cbThemeSettings_SelectionChanged;
+
+            transparencyCheckBox.IsChecked = (loadSettings("transparency") as bool?) ?? false;
         }
 
         private void cbThemeSettings_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -76,7 +78,17 @@ namespace AppAppBar3
                 && Enum.TryParse<ElementTheme>(s, out var t))
             {
                 ThemeHelper.SaveAndApply(t);
+                // Backdrop preference depends on theme = Default; switching to
+                // Light / Dark must turn the backdrop off (and back on if user
+                // returns to Default with transparency enabled).
+                parentWindow.ApplyBackdropPreference();
             }
+        }
+
+        private void transparencyCheckBox_Click(object sender, RoutedEventArgs e)
+        {
+            saveSetting("transparency", transparencyCheckBox.IsChecked == true);
+            parentWindow.ApplyBackdropPreference();
         }
 
         private void autohideCheckBox_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Adds a Settings checkbox **"Translucent background (Theme = Default)"** that, when enabled while the user is following the Windows theme, sets `MainWindow.SystemBackdrop = new DesktopAcrylicBackdrop()` (`Microsoft.UI.Xaml.Media`) and clears the StackPanel's solid fill so the acrylic shows through — visually matching the Windows 11 taskbar.

## Why scope it to Theme = Default
Translucency is a system effect; it tints with whatever Windows is rendering behind. If the user explicitly picks Light or Dark, that color choice should win, so the backdrop is automatically suppressed in that case (and re-enabled if they switch back to Default with transparency on).

## Implementation
- `MainWindow.ApplyBackdropPreference()` reads `loadSettings("transparency")` + `ThemeHelper.LoadSavedTheme()`. If both conditions hold, install the backdrop and `stPanel.Background = Transparent`. Otherwise null the backdrop and restore the chrome fill via the active theme dictionary.
- Invoked from: `OnActivated` (initial paint), `restartAppBar` (bar size / monitor / autohide), the Settings theme dropdown handler, and the new transparency checkbox.
- Settings window grows 450 → 490 px to fit the new row.
- `SettingMethods.setDefaultValues` adds `"transparency": false`.

Four files, +46 / −2.

## Test plan
- [ ] CI green.
- [ ] Theme = Default + checkbox on: AppBar shows the desktop acrylic blur (windows behind it bleed through faintly, similar to the taskbar).
- [ ] Toggle off: solid chrome returns immediately.
- [ ] Theme = Light or Dark + checkbox on: backdrop stays off (explicit color wins).
- [ ] Switch back to Default with checkbox still on: backdrop returns.
- [ ] Bar size / autohide / monitor changes: backdrop survives the restart path.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_