### PR TITLE
Thinner acrylic translucency; fix shortcut clipping in vertical dock

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -767,6 +767,7 @@ namespace AppAppBar3
                 bi.SetSource(iconThumbnail);
 
                 double iconSize = CurrentIconSize;
+                int barSize = (loadSettings("bar_size") as int?) ?? BaselineBarSize;
                 Image ButtonImageEL = new Image()
                 {
                     Source = bi,
@@ -774,10 +775,19 @@ namespace AppAppBar3
                     Width = iconSize,
                  };
 
+                // Constrain to a square the size of the bar so the button can't
+                // overflow the bar's narrow axis (vertical dock) — the theme's
+                // default Button Padding adds ~22 px horizontally and would
+                // otherwise clip the icon when the bar is docked Left or Right.
                 Button testIButton = new Button()
                 {
                     Background = new SolidColorBrush(Colors.Transparent),
                     BorderBrush = new SolidColorBrush(Colors.Transparent),
+                    Padding = new Thickness(0),
+                    Width = barSize,
+                    Height = barSize,
+                    HorizontalContentAlignment = HorizontalAlignment.Center,
+                    VerticalContentAlignment = VerticalAlignment.Center,
                     Content = ButtonImageEL,
                     Tag = aPath,
                  };
@@ -936,15 +946,19 @@ namespace AppAppBar3
             // doesn't expose one). Default FontIcon FontSize is 20.
             webIcon.FontSize = 20 * scale;
 
-            // Shortcut buttons live as direct children of stPanel (not VariableGrid);
-            // scale their Image content so the button auto-sizes to match.
+            // Shortcut buttons live as direct children of stPanel (not VariableGrid).
+            // Pin them to barSize x barSize with zero padding so they fit the bar's
+            // narrow axis in either orientation, then scale the inner Image to match.
             double iconSize = CurrentIconSize;
             foreach (var child in stPanel.Children)
             {
                 if (child is Button btn && btn.Content is Image img)
                 {
-                    img.Width  = iconSize;
-                    img.Height = iconSize;
+                    btn.Width   = barSize;
+                    btn.Height  = barSize;
+                    btn.Padding = new Thickness(0);
+                    img.Width   = iconSize;
+                    img.Height  = iconSize;
                 }
             }
         }

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -874,8 +874,17 @@ namespace AppAppBar3
 
             if (useBackdrop)
             {
-                if (this.SystemBackdrop == null)
-                    this.SystemBackdrop = new DesktopAcrylicBackdrop();
+                // Kind = Thin is the most translucent of the three DesktopAcrylic
+                // variants (Default, Base, Thin). Base is closer to the Win11
+                // taskbar's tint; Thin lets more of the desktop bleed through.
+                if (this.SystemBackdrop is not DesktopAcrylicBackdrop existing
+                    || existing.Kind != DesktopAcrylicKind.Thin)
+                {
+                    this.SystemBackdrop = new DesktopAcrylicBackdrop
+                    {
+                        Kind = DesktopAcrylicKind.Thin,
+                    };
+                }
                 stPanel.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
             }
             else


### PR DESCRIPTION
Two follow-ups to #30 / the translucent-background work.

## Commits
- **`5d3914c` Increase AppBar translucency via `DesktopAcrylicKind.Thin`**: the default `DesktopAcrylicBackdrop` is too opaque vs the Win11 taskbar feel. WinAppSDK exposes `Kind` (Default / Base / Thin); switching to `Thin` lets more of the desktop bleed through. Also reuses the existing backdrop instance when `Kind` already matches so `ApplyBackdropPreference` doesn't churn through new `SystemBackdrop`s on every restart.

- **`329d6cd` Pin shortcut buttons to barSize square so vertical dock doesn't clip**: shortcut Buttons in `createShortCut` were using the theme's default Padding (~11 px on each side), so a 32 px icon came out ~54 px wide. With the bar docked Left/Right at width 50 px, the button overflowed the bar's narrow axis and the icon (Chrome / etc.) got clipped. Pin shortcut buttons to `barSize × barSize` with `Padding="0"` and centered content alignment, applied both at creation time and in `RescaleControls`.

One file (`MainWindow.xaml.cs`), +29 / −6.

## Test plan
- [ ] CI green.
- [ ] Translucent-background mode (Theme = Default + checkbox on): AppBar visibly lets the desktop / windows bleed through more than before.
- [ ] Dock Left or Right with shortcuts present: Chrome / other shortcut icons render fully, not clipped on the right edge.
- [ ] Same in horizontal mode — no regression.
- [ ] Change bar size in Settings → existing shortcut buttons resize square to the new size.

## Known follow-up (not in this PR)
Shortcut buttons still use the theme-default hover/border. Inconsistent with the Web button's taskbar-style hover. Easy to address by extracting the Web button's `Resources` overrides into a shared `Style` and applying it to each newly-created shortcut Button, but holding off until you confirm you'd like that look on shortcuts too.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_