### PR TITLE
Backdrop revert + tint-opacity slider via DesktopAcrylicController

### DIFF
--- a/AppAppBar3/CustomAcrylicBackdrop.cs
+++ b/AppAppBar3/CustomAcrylicBackdrop.cs
@@ -1,0 +1,78 @@
+using Microsoft.UI.Composition;
+using Microsoft.UI.Composition.SystemBackdrops;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using System;
+using Windows.UI;
+
+namespace AppAppBar3
+{
+    // SystemBackdrop subclass that drives a DesktopAcrylicController directly,
+    // exposing TintOpacity and LuminosityOpacity as configurable knobs. The
+    // built-in DesktopAcrylicBackdrop in Microsoft.UI.Xaml.Media doesn't expose
+    // these in every WinAppSDK 1.x build (DesktopAcrylicKind.Thin / .Kind aren't
+    // present on the user's reference assemblies), so we manage the controller
+    // ourselves to give the user a slider for translucency.
+    public sealed class CustomAcrylicBackdrop : SystemBackdrop
+    {
+        private DesktopAcrylicController _controller;
+        private SystemBackdropConfiguration _config;
+
+        // 0.0 = pure see-through (no tint); 1.0 = solid tint color.
+        public float TintOpacity { get; set; } = 0.4f;
+
+        // 0.0 = clear glass; 1.0 = fully frosted.
+        public float LuminosityOpacity { get; set; } = 0.85f;
+
+        // null = let the controller pick a theme-appropriate default.
+        public Color? TintColor { get; set; }
+
+        protected override void OnTargetConnected(ICompositionSupportsSystemBackdrop connectedTarget, XamlRoot xamlRoot)
+        {
+            if (!DesktopAcrylicController.IsSupported())
+                return;
+
+            _config = new SystemBackdropConfiguration
+            {
+                IsInputActive = true,
+                Theme = ResolveTheme(xamlRoot),
+            };
+
+            _controller = new DesktopAcrylicController
+            {
+                TintOpacity = TintOpacity,
+                LuminosityOpacity = LuminosityOpacity,
+            };
+            if (TintColor.HasValue)
+                _controller.TintColor = TintColor.Value;
+
+            _controller.AddSystemBackdropTarget(connectedTarget);
+            _controller.SetSystemBackdropConfiguration(_config);
+        }
+
+        protected override void OnTargetDisconnected(ICompositionSupportsSystemBackdrop disconnectedTarget)
+        {
+            if (_controller != null)
+            {
+                _controller.RemoveSystemBackdropTarget(disconnectedTarget);
+                _controller.Dispose();
+                _controller = null;
+            }
+            _config = null;
+        }
+
+        private static SystemBackdropTheme ResolveTheme(XamlRoot xamlRoot)
+        {
+            if (xamlRoot?.Content is FrameworkElement fe)
+            {
+                return fe.ActualTheme switch
+                {
+                    ElementTheme.Dark => SystemBackdropTheme.Dark,
+                    ElementTheme.Light => SystemBackdropTheme.Light,
+                    _ => SystemBackdropTheme.Default,
+                };
+            }
+            return SystemBackdropTheme.Default;
+        }
+    }
+}

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -884,8 +884,17 @@ namespace AppAppBar3
 
             if (useBackdrop)
             {
-                if (this.SystemBackdrop == null)
-                    this.SystemBackdrop = new DesktopAcrylicBackdrop();
+                // Tint opacity is stored as 0-100; the controller wants 0.0-1.0.
+                int tintPercent = (loadSettings("tint_opacity") as int?) ?? 40;
+                float tint = Math.Clamp(tintPercent, 0, 100) / 100f;
+
+                // Always replace the backdrop when the slider moved so the new
+                // TintOpacity takes effect; the controller doesn't expose a way
+                // to update opacity after AddSystemBackdropTarget without a rebuild.
+                this.SystemBackdrop = new CustomAcrylicBackdrop
+                {
+                    TintOpacity = tint,
+                };
                 stPanel.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
             }
             else

--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -884,17 +884,8 @@ namespace AppAppBar3
 
             if (useBackdrop)
             {
-                // Kind = Thin is the most translucent of the three DesktopAcrylic
-                // variants (Default, Base, Thin). Base is closer to the Win11
-                // taskbar's tint; Thin lets more of the desktop bleed through.
-                if (this.SystemBackdrop is not DesktopAcrylicBackdrop existing
-                    || existing.Kind != DesktopAcrylicKind.Thin)
-                {
-                    this.SystemBackdrop = new DesktopAcrylicBackdrop
-                    {
-                        Kind = DesktopAcrylicKind.Thin,
-                    };
-                }
+                if (this.SystemBackdrop == null)
+                    this.SystemBackdrop = new DesktopAcrylicBackdrop();
                 stPanel.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
             }
             else

--- a/AppAppBar3/SettingMethods.cs
+++ b/AppAppBar3/SettingMethods.cs
@@ -66,6 +66,7 @@ namespace AppAppBar3
             saveSetting("autohide", false);
             saveSetting("theme", "Default");
             saveSetting("transparency", false);
+            saveSetting("tint_opacity", 40);
         }
 
         public static void saveSetting(string setting, object value)

--- a/AppAppBar3/Settings.xaml
+++ b/AppAppBar3/Settings.xaml
@@ -10,11 +10,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="Settings"
-    Height="490"
+    Height="560"
     Width="300"
     IsShownInSwitchers="False">
 
-    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="490" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
+    <StackPanel Background="{ThemeResource SystemChromeMediumLowColor}" Height="560" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="Vertical">
         
           
         <TextBlock Margin="10,10,0,0">Startup Edge:</TextBlock>
@@ -37,6 +37,11 @@
             <TextBlock Margin="10,10,0,0">Theme:</TextBlock>
             <ComboBox x:Name="cbThemeSettings" Margin="10,10,0,0" Width="200" MinWidth="200" SelectionChanged="cbThemeSettings_SelectionChanged"/>
             <CheckBox x:Name="transparencyCheckBox" Click="transparencyCheckBox_Click" Margin="10,10,0,0" Content="Translucent background (Theme = Default)" IsTabStop="False"/>
+            <TextBlock x:Name="tintOpacityLabel" Margin="10,10,0,0" Text="Tint opacity (lower = more translucent):"/>
+            <Slider x:Name="tintOpacitySlider" Margin="10,5,10,0"
+                    Minimum="0" Maximum="100"
+                    StepFrequency="5" TickFrequency="10" TickPlacement="BottomRight"
+                    ValueChanged="tintOpacitySlider_ValueChanged"/>
         
 
 

--- a/AppAppBar3/Settings.xaml.cs
+++ b/AppAppBar3/Settings.xaml.cs
@@ -70,6 +70,19 @@ namespace AppAppBar3
             cbThemeSettings.SelectionChanged += cbThemeSettings_SelectionChanged;
 
             transparencyCheckBox.IsChecked = (loadSettings("transparency") as bool?) ?? false;
+
+            // Tint slider: detach handler during the initial Value set so the
+            // ValueChanged path doesn't fire a redundant SaveAndApply on open.
+            tintOpacitySlider.ValueChanged -= tintOpacitySlider_ValueChanged;
+            tintOpacitySlider.Value = (loadSettings("tint_opacity") as int?) ?? 40;
+            tintOpacitySlider.IsEnabled = transparencyCheckBox.IsChecked == true;
+            tintOpacitySlider.ValueChanged += tintOpacitySlider_ValueChanged;
+        }
+
+        private void tintOpacitySlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            saveSetting("tint_opacity", (int)tintOpacitySlider.Value);
+            parentWindow.ApplyBackdropPreference();
         }
 
         private void cbThemeSettings_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -87,7 +100,9 @@ namespace AppAppBar3
 
         private void transparencyCheckBox_Click(object sender, RoutedEventArgs e)
         {
-            saveSetting("transparency", transparencyCheckBox.IsChecked == true);
+            bool on = transparencyCheckBox.IsChecked == true;
+            saveSetting("transparency", on);
+            tintOpacitySlider.IsEnabled = on;
             parentWindow.ApplyBackdropPreference();
         }
 


### PR DESCRIPTION
Two commits stacked on `Experimental-2`.

## Commits

- **`b71b7d9` Revert backdrop Kind tweaks** — `DesktopAcrylicKind` / `MicaKind` `Kind` is missing on the user's WinAppSDK reference, broke compile. Restored plain `new DesktopAcrylicBackdrop()`.

- **`cce960c` Tint-opacity slider via DesktopAcrylicController** — drops down to `Microsoft.UI.Composition.SystemBackdrops.DesktopAcrylicController` to control translucency without depending on `Kind`:
  - New `CustomAcrylicBackdrop : SystemBackdrop` manages controller lifecycle in `OnTargetConnected` / `OnTargetDisconnected`. Exposes `TintOpacity` (0.0–1.0).
  - Settings adds a `Slider` "Tint opacity" (0–100, step 5, ticks every 10) below the Translucent-background checkbox. `IsEnabled` tracks the checkbox; `ValueChanged` saves and rebuilds the backdrop.
  - `SettingMethods` adds `"tint_opacity": 40` to defaults.
  - `MainWindow.ApplyBackdropPreference` rebuilds a fresh `CustomAcrylicBackdrop` each call (controllers snapshot initial values).
  - Settings window grows 490 → 560 px.

Six files, +115 / −16.

## Test plan
- [ ] CI green.
- [ ] Theme = Default + checkbox on: AppBar shows acrylic at the saved tint (40% by default).
- [ ] Drag slider → translucency updates immediately; lower values show more desktop bleed-through.
- [ ] Toggle checkbox off → solid chrome returns; slider greys out.
- [ ] Switch to explicit Light / Dark → backdrop suppressed; slider value retained for when user returns to Default.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH