### PR TITLE
Tint slider drives LuminosityOpacity too for visible translucency range

### DIFF
--- a/AppAppBar3/MainWindow.xaml.cs
+++ b/AppAppBar3/MainWindow.xaml.cs
@@ -884,16 +884,22 @@ namespace AppAppBar3
 
             if (useBackdrop)
             {
-                // Tint opacity is stored as 0-100; the controller wants 0.0-1.0.
-                int tintPercent = (loadSettings("tint_opacity") as int?) ?? 40;
-                float tint = Math.Clamp(tintPercent, 0, 100) / 100f;
+                // Slider value is stored 0-100. Drive BOTH TintOpacity and
+                // LuminosityOpacity from it so dragging produces a visible range:
+                // TintOpacity alone barely affects translucency — LuminosityOpacity
+                // controls the frosted-vs-clear-glass character and is what the
+                // user sees move when they drag the slider. At 0 the bar is
+                // near-fully see-through; at 100 it's heavily tinted/frosted.
+                int sliderPercent = (loadSettings("tint_opacity") as int?) ?? 40;
+                float opacity = Math.Clamp(sliderPercent, 0, 100) / 100f;
 
                 // Always replace the backdrop when the slider moved so the new
-                // TintOpacity takes effect; the controller doesn't expose a way
-                // to update opacity after AddSystemBackdropTarget without a rebuild.
+                // values take effect; DesktopAcrylicController snapshots the
+                // initial opacity values when AddSystemBackdropTarget runs.
                 this.SystemBackdrop = new CustomAcrylicBackdrop
                 {
-                    TintOpacity = tint,
+                    TintOpacity = opacity,
+                    LuminosityOpacity = opacity,
                 };
                 stPanel.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
             }


### PR DESCRIPTION
Single-commit follow-up. The slider added in #32 only mapped to `TintOpacity`, which barely changes how see-through the acrylic looks — `TintOpacity` controls how saturated the tint *color* is, not how transparent the glass is. The property the user actually wants on the slider is `LuminosityOpacity` (frosted-vs-clear glass).

## Change
In `MainWindow.ApplyBackdropPreference`, drive **both** `TintOpacity` and `LuminosityOpacity` from the same 0–100 slider percent. Result: at 0 the bar is near fully see-through; at 100 it's heavily tinted and frosted; the existing 40% default sits in between.

One file (`MainWindow.xaml.cs`), +12 / −6.

## Test plan
- [ ] CI green.
- [ ] Theme = Default + Translucent on: drag slider 0 → 100 and confirm the bar visibly transitions from "near-clear" to "heavily tinted/frosted" (not the previous "barely changes").
- [ ] At 0%, the desktop / windows behind the bar should bleed through prominently.
- [ ] At 100%, the bar reads close to the solid chrome color.

https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH

---
_Generated by [Claude Code](https://claude.ai/code/session_016Kw5HQ9QYd84V2HKF2YXTH)_